### PR TITLE
Added border to upper searchBar

### DIFF
--- a/Cyberpunk Theme/CyberpunkTheme.vstheme
+++ b/Cyberpunk Theme/CyberpunkTheme.vstheme
@@ -7649,7 +7649,7 @@
         <Background Type="CT_RAW" Source="00B6005B" />
       </Color>
       <Color Name="UnfocusedBorder">
-        <Background Type="CT_RAW" Source="009F005A" />
+        <Background Type="CT_RAW" Source="FF169AFF" />
       </Color>
       <Color Name="Disabled">
         <Background Type="CT_RAW" Source="FF000B1E" />


### PR DESCRIPTION
Since quite often when moving around the screen my visual code, I often press the search bar space (marked in red square). 
![image](https://user-images.githubusercontent.com/47099440/155866125-b4ff8bc8-6e2a-4e57-ad43-45cefe81fde5.png)
So I just added the UnfocusedBorder color to the default blue one.
![image](https://user-images.githubusercontent.com/47099440/155866177-14862689-00c5-4c98-9f08-e600f2434d82.png)
