### PR TITLE
Add missing colors for C# tokens

### DIFF
--- a/Cyberpunk Theme/CyberpunkTheme.vstheme
+++ b/Cyberpunk Theme/CyberpunkTheme.vstheme
@@ -2149,11 +2149,11 @@
       </Color>
       <Color Name="keyword - control">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF9090" />
       </Color>
       <Color Name="operator - overloaded">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00FF9F" />
       </Color>
       <Color Name="record class name">
         <Background Type="CT_INVALID" Source="00000000" />
@@ -2161,15 +2161,15 @@
       </Color>
       <Color Name="field name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00E0B0" />
       </Color>
       <Color Name="enum member name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00A40B" />
       </Color>
       <Color Name="constant name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF95A8E8" />
       </Color>
       <Color Name="local name">
         <Background Type="CT_INVALID" Source="00000000" />
@@ -2177,7 +2177,7 @@
       </Color>
       <Color Name="parameter name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFE9400" />
       </Color>
       <Color Name="method name">
         <Background Type="CT_INVALID" Source="00000000" />
@@ -2185,15 +2185,15 @@
       </Color>
       <Color Name="extension method name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF267FC2" />
       </Color>
       <Color Name="property name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF85C1" />
       </Color>
       <Color Name="event name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF7C7C7C" />
       </Color>
       <Color Name="namespace name">
         <Background Type="CT_INVALID" Source="00000000" />
@@ -2201,7 +2201,7 @@
       </Color>
       <Color Name="label name">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF7B411" />
       </Color>
       <Color Name="regex - comment">
         <Background Type="CT_INVALID" Source="00000000" />

--- a/Cyberpunk Theme/source.extension.vsixmanifest
+++ b/Cyberpunk Theme/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
 	<Metadata>
-		<Identity Id="Cyberpunk_Theme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="2.3" Language="en-US" Publisher="T0uchM3" />
+		<Identity Id="Cyberpunk_Theme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="2.4" Language="en-US" Publisher="T0uchM3" />
 		<DisplayName>Cyberpunk - Theme</DisplayName>
 		<Description xml:space="preserve">Cyberpunk theme for visual studio.</Description>
 		<Icon>icon.jpg</Icon>


### PR DESCRIPTION
This would fix #25 

Where I could, I used the colors that were already being used by the C++ highlighting. The only real decision I made was for the "extension method" token.

C++ doesn't really have an equivalent, so I used the color of "CppFunctionSemanticTokenFormat"

Of course any of the colors can be changed, I just wanted to get _something_ in there so the tokens would be easier for me to read.

Here is a preview of all of the new colors:
<img width="792" height="1056" alt="image" src="https://github.com/user-attachments/assets/43899770-9198-45df-86f6-20f5cb6815dc" />

