### PR TITLE
Visual Studio 2026 Support

### DIFF
--- a/Cyberpunk Theme/CyberpunkTheme.vstheme
+++ b/Cyberpunk Theme/CyberpunkTheme.vstheme
@@ -1,5 +1,5 @@
 ﻿<Themes>
-  <Theme Name="Cyberpunk" GUID="{37868443-43b2-4023-a370-220a0e3449dd}" BaseGUID="{a147e2d4-5eda-4c9d-9e1f-7fcde5307581}">
+  <Theme Name="Cyberpunk" GUID="{37868443-43b2-4023-a370-220a0e3449dd}" BaseGUID="{a147e2d4-5eda-4c9d-9e1f-7fcde5307581}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
     <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
       <Color Name="Body">
         <Background Type="CT_RAW" Source="FF090C1D" />
@@ -12761,5 +12761,51 @@
         <Foreground Type="CT_RAW" Source="FF839496" />
       </Color>
     </Category>
-  </Theme>
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+        <Color Name="AccentFillDefault">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="AccentFillSecondary">
+            <Background Type="CT_RAW" Source="39082CE5" />
+        </Color>
+        <Color Name="AccentFillTertiary">
+            <Background Type="CT_RAW" Source="39082CCC" />
+        </Color>
+        <Color Name="SolidBackgroundFillTertiary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SolidBackgroundFillQuaternary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SurfaceBackgroundFillDefault">
+            <Background Type="CT_RAW" Source="FF2C2C2C" />
+        </Color>
+        <Color Name="TextFillSecondary">
+            <Background Type="CT_RAW" Source="FFFFFFCC" />
+        </Color>
+    </Category>
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+        <Color Name="EnvironmentBackground">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="EnvironmentBorder">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentBorderInactive">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentIndicator">
+            <Background Type="CT_RAW" Source="ffffff60" />
+        </Color>
+        <Color Name="EnvironmentLogo">
+            <Background Type="CT_RAW" Source="FFEE0077" />
+        </Color>
+        <Color Name="EnvironmentLayeredBackground">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+        <Color Name="StatusBarBackgroundFillSolutionLoading">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+    </Category>
+    </Theme>
 </Themes>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyberpunk-Theme
 
-Dark "Cyberpunk" theme for visual studio 2019 and 2022 <br>
+Dark "Cyberpunk" theme for visual studio 2019, 2022, and 2026. <br>
 # C#
 <img src="https://github.com/T0uchM3/Cyberpunk-Theme/blob/master/Cyberpunk%20Theme/preview2.png"><br>
 # C++ (OLD)


### PR DESCRIPTION
Implements the changes required by https://learn.microsoft.com/en-us/visualstudio/extensibility/migration/modernize-theme-colors?view=visualstudio for Visual Studio 2026 support. 

a couple of screen shot showing it running in VS26

![2025-12-10_13-12-29](https://github.com/user-attachments/assets/f5c6fea6-77ec-4601-960e-db58b14914a4)
![2025-12-10_13-14-31](https://github.com/user-attachments/assets/e3c35f6a-1657-4530-9eb4-29ffeab0f348)
