### PR TITLE
VS 2026 support

### DIFF
--- a/Cyberpunk Theme/Cyberpunk Theme.csproj
+++ b/Cyberpunk Theme/Cyberpunk Theme.csproj
@@ -46,6 +46,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="CyberpunkClassicTheme.vstheme">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="CyberpunkTheme.vstheme">
       <SubType>Designer</SubType>
     </None>

--- a/Cyberpunk Theme/CyberpunkClassicTheme.vstheme
+++ b/Cyberpunk Theme/CyberpunkClassicTheme.vstheme
@@ -1,0 +1,12811 @@
+﻿<Themes>
+  <Theme Name="Cyberpunk (Classic)" GUID="{37868443-43b2-4023-a370-220a0e3445dd}" BaseGUID="{a147e2d4-5eda-4c9d-9e1f-7fcde5307581}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
+    <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
+      <Color Name="Body">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="H1">
+        <Foreground Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="Chevron">
+        <Foreground Type="CT_SYSCOLOR" Source="FFB9A1CF" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Foreground Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="HyperlinkActive">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="NumberedListItem">
+        <Background Type="CT_RAW" Source="FFA7B7D0" />
+        <Foreground Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="NumberedListItemHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NumberedListItemHoverBorder">
+        <Foreground Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NumberedListItemActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NumberedListItemActiveBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ContentSectionHeader">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="ContentSectionHeaderBorder">
+        <Foreground Type="CT_RAW" Source="FF103156" />
+      </Color>
+    </Category>
+    <Category Name="ApacheCordovaToolsColors" GUID="{badebe03-e60e-41de-8b51-5a379a844217}">
+      <Color Name="ConfigEditorHeader">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorListPane">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="ConfigEditorDetailPane">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="ConfigEditorPrimaryNavPane">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavPane">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="ConfigEditorLegalMessage">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ConfigEditorPaneBorder">
+        <Background Type="CT_RAW" Source="FFE5E5EB" />
+      </Color>
+      <Color Name="ConfigEditorDivisionBorder">
+        <Background Type="CT_RAW" Source="FFE5E5EB" />
+      </Color>
+      <Color Name="ConfigEditorPrimaryNavItem">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ConfigEditorPrimaryNavItemHover">
+        <Background Type="CT_RAW" Source="FFB5CAE7" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ConfigEditorPrimaryNavItemSelected">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorPrimaryNavItemSecondarySelection">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItem">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemHover">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemHoverBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemSelected">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemPressed">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="ConfigEditorSecondaryNavItemPressedBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorPluginsStatusFeedback">
+        <Background Type="CT_RAW" Source="FFD8E7F6" />
+      </Color>
+      <Color Name="ConfigEditorPluginsListItem">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="ConfigEditorPluginsListItemHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ConfigEditorPluginsListItemSelected">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="ApacheCordovaToolsSimulateColors" GUID="{03a4047b-0708-4d55-93bb-ce6d3ef68257}">
+      <Color Name="SimulateBody">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="SimulateButton">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateButtonActive">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateButtonActiveBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateButtonBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="SimulateButtonFocus">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateButtonFocusBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateButtonHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateButtonHoverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateCheck">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateCheckBorder">
+        <Background Type="CT_RAW" Source="FF9696A0" />
+      </Color>
+      <Color Name="SimulateCheckFocus">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateCheckFocusBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateCheckHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateCheckHoverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateDefault">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateInput">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateInputBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="SimulateInputFocus">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateInputFocusBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateInputHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateInputHoverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateLabel">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulatePanel">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulatePanelBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="SimulatePanelCaption">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulatePanelCaptionFocus">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulatePanelFocus">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulatePanelFocusBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateThumb">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SimulateThumbBorder">
+        <Background Type="CT_RAW" Source="FF9696A0" />
+      </Color>
+      <Color Name="SimulateThumbFocus">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+      </Color>
+      <Color Name="SimulateThumbFocusBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateThumbHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+      </Color>
+      <Color Name="SimulateThumbHoverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="SimulateValue">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="ApplicationInsights" GUID="{fb17cf37-09ea-44a4-88a6-cd806fc6a24a}">
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="Button">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ButtonHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LandingPageBackground">
+        <Background Type="CT_RAW" Source="FF404040" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LandingPageLetters">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AIGrayText">
+        <Background Type="CT_RAW" Source="FFAAAAAA" />
+      </Color>
+      <Color Name="Success">
+        <Background Type="CT_RAW" Source="FF7E0032" />
+      </Color>
+      <Color Name="Error">
+        <Background Type="CT_RAW" Source="FFFF4040" />
+      </Color>
+      <Color Name="TrendsAssistanceItemHeader">
+        <Foreground Type="CT_RAW" Source="FFFFA500" />
+      </Color>
+      <Color Name="TrendsShapesRegular">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="TrendsShapesHighlighted">
+        <Background Type="CT_RAW" Source="FFFFD700" />
+      </Color>
+      <Color Name="StatusOK">
+        <Background Type="CT_RAW" Source="FF4EB543" />
+      </Color>
+      <Color Name="StatusPending">
+        <Background Type="CT_RAW" Source="FFE00000" />
+      </Color>
+      <Color Name="StatusWarning">
+        <Background Type="CT_RAW" Source="FFF1CA5D" />
+      </Color>
+      <Color Name="AIPurple">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LandingPageConstrastBackground">
+        <Background Type="CT_RAW" Source="FF292929" />
+      </Color>
+      <Color Name="BorderLightContrast">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="Squiggly">
+        <Background Type="CT_RAW" Source="FFDBE5F5" />
+      </Color>
+      <Color Name="LiveMetricsRequestStroke">
+        <Background Type="CT_RAW" Source="FF56B45D" />
+      </Color>
+      <Color Name="LiveMetricsRequestFill">
+        <Background Type="CT_RAW" Source="FF294033" />
+      </Color>
+      <Color Name="LiveMetricsFailedRequestStroke">
+        <Background Type="CT_RAW" Source="FFEA485C" />
+      </Color>
+      <Color Name="LiveMetricsFailedRequestFill">
+        <Background Type="CT_RAW" Source="FF4C2728" />
+      </Color>
+      <Color Name="SquigglyOrange">
+        <Background Type="CT_RAW" Source="00FF9427" />
+      </Color>
+    </Category>
+    <Category Name="Autos" GUID="{a7ee6bee-d0aa-4b2f-ad9d-748276a725f6}">
+      <Color Name="ChangedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF7A1A1" />
+      </Color>
+      <Color Name="Plain Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="CallStack" GUID="{fd2219af-ebf8-4116-a801-3b503c48dff0}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Cider" GUID="{92d153ee-57d7-431f-a739-0931ca3f7f70}">
+      <Color Name="ToolWindow">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowShelf">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowGroup">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowGroupSecondary">
+        <Background Type="CT_RAW" Source="FF292929" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabBackground">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="TabBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="TabItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="TabItem">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabItemBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="TabItemDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="TabItemDisabledBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="TabItemMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TabItemSelected">
+        <Background Type="CT_RAW" Source="FF04071F" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="HyperlinkMouseOver">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="GlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="Glyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InputDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Input">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InputBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InputMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InputMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InputDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ListItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ListItem">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ListItemMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="ListItemSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemDisabledBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ListItemDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ToggleDisabledBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="Command">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CommandBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CommandMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CommandPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandPressedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CommandDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Toggle">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToggleBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToggleMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToggleMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToggleSelected">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToggleSelectedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToggleDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBox">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF6D6D6D" />
+      </Color>
+      <Color Name="ComboBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxButtonBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxButtonPressedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxPopUpBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxPopUp">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ArtboardButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ArtboardBackground">
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ArtboardWindow">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ArtboardWindowBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="PropertyValueBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StructureViewChildSelected">
+        <Background Type="CT_RAW" Source="FFBABABA" />
+      </Color>
+      <Color Name="StructureViewActiveContainer">
+        <Background Type="CT_RAW" Source="FFEDC865" />
+      </Color>
+      <Color Name="StructureViewDropTargetSplit">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StructureViewInsertionContainer">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PropertyDotBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="PropertyValueLocal">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MenuSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Menu">
+        <Background Type="CT_RAW" Source="FF04071F" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MenuBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToggleOuterBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SplitBarTab">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SplitBarTabSelected">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InteractiveIconMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InteractiveIcon">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SplitBar">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="HyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="HueSelectionGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="IconButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="IconButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="IconButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DialogExpanderGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DialogSearchControlButtonDisabledGlyph">
+        <Background Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="DialogSearchControlSearchGlyph">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="DialogSearchControlClearGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DialogExpanderGlyph">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DialogExpanderSelectedItemActiveGlyph">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ComboBoxMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ControlBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="BrushGradientStopOuterBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="BrushGradientStopInnerBorder">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowGroupDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="AnimationRecordingOff">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="AnimationRecordingIndication">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="AnimationRecordingOn">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowGroupBottomBorder">
+        <Background Type="CT_RAW" Source="FF333333" />
+      </Color>
+      <Color Name="ArtboardSecondaryBackground">
+        <Background Type="CT_RAW" Source="FF1A1A1A" />
+      </Color>
+      <Color Name="ListItemTier1">
+        <Background Type="CT_RAW" Source="FF424242" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemTier1Border">
+        <Background Type="CT_RAW" Source="FF424242" />
+      </Color>
+      <Color Name="ListItemTier2">
+        <Background Type="CT_RAW" Source="FF3C3C3C" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemTier2Border">
+        <Background Type="CT_RAW" Source="FF3C3C3C" />
+      </Color>
+      <Color Name="ListItemTier3">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemTier3Border">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ListItemSearchResult">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ListItemSearchResultDisabled">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ListItemSearchResultBorder">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ArtboardGuide">
+        <Background Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="FloatingMenu">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="FloatingMenuBorder">
+        <Background Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="TimelinePropertyXamlBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TimelineElementXamlBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TimelineXamlForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StylePaneRuleScopeAdorner">
+        <Background Type="CT_RAW" Source="2878A54E" />
+      </Color>
+      <Color Name="TimelinePlayHead">
+        <Background Type="CT_RAW" Source="FFFFA200" />
+      </Color>
+      <Color Name="TimelineDivider">
+        <Background Type="CT_RAW" Source="FF4F4F4F" />
+      </Color>
+      <Color Name="TimelineKeyframe">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TimelineKeyframeBorder">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TimelineKeyframeSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TimelineKeyframeSelectedBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="TimelineDurationBarGripper">
+        <Background Type="CT_RAW" Source="FFDBDBDB" />
+      </Color>
+      <Color Name="TimelineDurationLiveKeyframe">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="TimelineDurationBarSelector">
+        <Background Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="TimelineDurationBarIterationDivider">
+        <Background Type="CT_RAW" Source="B2DB68A2" />
+      </Color>
+      <Color Name="TimelineDurationBarLiveIterationDivider">
+        <Background Type="CT_RAW" Source="B2A85182" />
+      </Color>
+      <Color Name="TimelineDurationBarIteration">
+        <Background Type="CT_RAW" Source="4CDB68A2" />
+      </Color>
+      <Color Name="TimelineDurationBarLiveIteration">
+        <Background Type="CT_RAW" Source="4CA85182" />
+      </Color>
+      <Color Name="TimelineDurationBarIterationLabel">
+        <Background Type="CT_RAW" Source="B2DB68A2" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TimelineDurationBarLiveIterationLabel">
+        <Background Type="CT_RAW" Source="FFA85182" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TimelineDurationBarFillMode">
+        <Background Type="CT_RAW" Source="33A6A6A6" />
+      </Color>
+      <Color Name="TimelineDurationBarFillModeStripePattern">
+        <Background Type="CT_RAW" Source="FF404040" />
+      </Color>
+      <Color Name="ArtboardElement">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ArtboardDistance">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ArtboardDistanceSelected">
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ArtboardTick">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Databinding">
+        <Background Type="CT_RAW" Source="FFFFCF00" />
+      </Color>
+      <Color Name="LiveValue">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="UnparsedValue">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="TimelineDurationBarParent">
+        <Background Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="TimelineDurationBarChild">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ResourceLink">
+        <Background Type="CT_RAW" Source="FF8ABB2E" />
+      </Color>
+      <Color Name="Style">
+        <Background Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="Inheritance">
+        <Background Type="CT_RAW" Source="FF8A2BE2" />
+      </Color>
+      <Color Name="DisabledOverlay">
+        <Background Type="CT_RAW" Source="22FFFFFF" />
+      </Color>
+      <Color Name="TransitionSliderDisabled">
+        <Background Type="CT_RAW" Source="FF222222" />
+      </Color>
+      <Color Name="TransitionKeyframeClip">
+        <Background Type="CT_RAW" Source="FF4A6A8F" />
+      </Color>
+      <Color Name="TimelineDurationKeyframe">
+        <Background Type="CT_RAW" Source="B2DB68A2" />
+      </Color>
+      <Color Name="ListBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="BreadcrumbBar">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="BreadcrumbButtonInactive">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="BreadcrumbButtonInactiveBorder">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="BreadcrumbButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BreadcrumbButtonOnHover">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BreadcrumbButtonSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BreadcrumbButtonSelectedOnHover">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListHeader">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Dialog">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DialogBorder">
+        <Background Type="CT_RAW" Source="FF595959" />
+      </Color>
+      <Color Name="CategoryTree">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="EasingFunction">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="DimmedText">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="TimelineDurationBarKeyframeGripper">
+        <Background Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="ListItemSecondary">
+        <Background Type="CT_RAW" Source="FF666666" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemSecondaryOnHover">
+        <Background Type="CT_RAW" Source="FF666666" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemSecondarySelected">
+        <Background Type="CT_RAW" Source="FF666666" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StatePinnedWithin">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StatePinnedActiveGroupBorder">
+        <Background Type="CT_RAW" Source="FFEDC865" />
+      </Color>
+      <Color Name="SecondaryBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="TimelineLabel">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ListBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="Toolbar">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolbarAsset">
+        <Background Type="CT_RAW" Source="FF3E424F" />
+      </Color>
+      <Color Name="GridSplitter">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolbarWatermark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="FloatingMenuMouseOver">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="LivePropertyExplorerResourceReference">
+        <Background Type="CT_RAW" Source="FF1CA11C" />
+      </Color>
+      <Color Name="ArtboardBackgroundDefault">
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ArtboardSecondaryBackgroundDefault">
+        <Background Type="CT_RAW" Source="FF1A1A1A" />
+      </Color>
+      <Color Name="ArtboardBackgroundAlternate">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ArtboardSecondaryBackgroundAlternate">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+    </Category>
+    <Category Name="ClientDiagnosticsMemory" GUID="{4ec0c2e0-c165-47be-9f29-2d2b73ad3e93}">
+      <Color Name="DropDownButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownButtonHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SnapshotButton">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="SnapshotButtonActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SnapshotButtonBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="SnapshotButtonBorderActive">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="SnapshotButtonBorderHover">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SnapshotButtonDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SnapshotButtonDisabledText">
+        <Foreground Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SnapshotButtonHover">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="SnapshotDiffAddedText">
+        <Foreground Type="CT_RAW" Source="FF75BF5B" />
+      </Color>
+      <Color Name="SnapshotDiffModifiedText">
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="SnapshotMessagesBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SnapshotTile">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="SnapshotTileBaselineText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="SnapshotTileBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="SnapshotTileErrorText">
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="SnapshotTileHeader">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TabHeader">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="TabText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TabHover">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+    </Category>
+    <Category Name="ClientDiagnosticsTimeline" GUID="{694a8994-9208-45d6-bf31-c58f96236fbe}">
+      <Color Name="GraphBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="DropDownButtonHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+    </Category>
+    <Category Name="ClientDiagnosticsTools" GUID="{9e505e47-0d0d-4681-8c9c-baa2a07771b7}">
+      <Color Name="GridCellBorder">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InactiveSelectedBackgroundColor">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InactiveSelectedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MouseOverBackgroundColor">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="MouseOverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SelectedBackgroundColor">
+        <Background Type="CT_RAW" Source="FF3213F0" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DetailPane">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FocusDots">
+        <Foreground Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="GridColumnSizer">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="GridHeaderHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridHeaderText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Menu">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="MenuBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="MenuFocus">
+        <Background Type="CT_RAW" Source="72555555" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MenuHover">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Progress">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="Splitter">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="WatermarkText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="NetworkCacheSelectedText">
+        <Foreground Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="NetworkCacheBlurText">
+        <Foreground Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="NetworkErrorSelectedText">
+        <Foreground Type="CT_RAW" Source="FFE61E27" />
+      </Color>
+      <Color Name="NetworkErrorBlurText">
+        <Foreground Type="CT_RAW" Source="FFE61E27" />
+      </Color>
+      <Color Name="NetworkToolbarButtonTextColor">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NetworkToolbarButtonHoverTextColor">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPopupTextColor">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPressedTextColor">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NetworkGridSecondaryHighlighted">
+        <Foreground Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="NetworkGridSecondarySelected">
+        <Foreground Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="NetworkHeaderBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+    </Category>
+    <Category Name="CodeAnalysis" GUID="{bbadd5c0-3c00-4c56-aae8-92cd1d1f516b}">
+      <Color Name="RenameError">
+        <Foreground Type="CT_RAW" Source="FFFF5B5B" />
+      </Color>
+      <Color Name="RenameResolvableConflict">
+        <Foreground Type="CT_RAW" Source="FF90EE90" />
+      </Color>
+    </Category>
+    <Category Name="CodeSense" GUID="{fc88969a-cbed-4940-8f48-142a503e2381}">
+      <Color Name="IndicatorText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="IndicatorTextHovered">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="IndicatorTextDisabled">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="IndicatorSeparator">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="IndicatorTextSelected">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="CodeSenseControls" GUID="{de7b1121-99a4-4708-aedf-15f40c9b332f}">
+      <Color Name="SubduedText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ActionLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkDisabled">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ActionLinkItem">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkItemSelected">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActionLinkItemDisabled">
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ActionLinkItemSelectedNotFocused">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkItemHover">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ItemHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ItemSelectedText">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BodyText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DiffViewHighlight">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SubduedBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="PopupSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupHover">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="TextSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GrayText">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="HeaderText">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="TextHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GrayTextHover">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="Popup">
+        <Background Type="CT_RAW" Source="FF001F1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupBorder">
+        <Background Type="CT_RAW" Source="FF41001B" />
+      </Color>
+      <Color Name="PopupPinButtonHover">
+        <Background Type="CT_RAW" Source="FF001F1E" />
+        <Foreground Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="PopupPinButtonMouseDown">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="YouAreHereText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="YouAreHereBackground">
+        <Background Type="CT_RAW" Source="FF960000" />
+      </Color>
+      <Color Name="PopupSelectedInactive">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RankedItemsFirst">
+        <Background Type="CT_RAW" Source="FF903F8B" />
+      </Color>
+      <Color Name="RankedItemsSecond">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="RankedItemsThird">
+        <Background Type="CT_RAW" Source="FF71B252" />
+      </Color>
+      <Color Name="RankedItemsFourth">
+        <Background Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="RankedItemsFifth">
+        <Background Type="CT_RAW" Source="FFB5B5B5" />
+      </Color>
+      <Color Name="ChartAxis">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="ChartTickMark">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="ChartSplitter">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="FileIndicatorPanelBorder">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+    </Category>
+    <Category Name="ColorizedSignatureHelp colors" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="Markup Attribute">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF8CF1EF" />
+      </Color>
+      <Color Name="Markup Attribute Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="Markup Node">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="Type">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF33A2A1" />
+      </Color>
+      <Color Name="CodeReview.SelectedComment.AnchorPoint">
+        <Background Type="CT_RAW" Source="FF067B7A" />
+        <Foreground Type="CT_RAW" Source="FF2FDCD7" />
+      </Color>
+      <Color Name="CodeReview.UnselectedComment.AnchorPoint">
+        <Background Type="CT_RAW" Source="FF067B7A" />
+        <Foreground Type="CT_RAW" Source="FF5DE7E3" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/HighlightedReference">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF35F7FF" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/FindHighlight">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/ScopeHighlight">
+        <Background Type="CT_RAW" Source="FF0F202D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Excluded Code">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9B9B9B" />
+      </Color>
+      <Color Name="Preprocessor Keyword">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF8D8A7F" />
+      </Color>
+      <Color Name="Operator">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFCEEEF0" />
+      </Color>
+      <Color Name="Literal">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDADADA" />
+      </Color>
+      <Color Name="SymbolDefinitionClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5F95FA" />
+      </Color>
+      <Color Name="SymbolReferenceClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF7CA5A0" />
+      </Color>
+      <Color Name="CurrentLineActiveFormat">
+        <Background Type="CT_RAW" Source="FF9976BA" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="deltadiff.remove.line">
+        <Background Type="CT_RAW" Source="FF2D0000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="deltadiff.add.line">
+        <Background Type="CT_RAW" Source="FF15352C" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="deltadiff.remove.word">
+        <Background Type="CT_RAW" Source="FF3C0000" />
+        <Foreground Type="CT_RAW" Source="FFFF6666" />
+      </Color>
+      <Color Name="deltadiff.add.word">
+        <Background Type="CT_RAW" Source="FF265E4D" />
+        <Foreground Type="CT_RAW" Source="FF76923C" />
+      </Color>
+      <Color Name="deltadiff.overview.color">
+        <Background Type="CT_RAW" Source="FF252925" />
+        <Foreground Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="outlining.collapsehintadornment">
+        <Background Type="CT_RAW" Source="FF111924" />
+        <Foreground Type="CT_RAW" Source="FFD7DDE8" />
+      </Color>
+      <Color Name="outlining.square">
+        <Background Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFC2006E" />
+      </Color>
+      <Color Name="urlformat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="NavigableSymbolFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="Track reverted changes">
+        <Background Type="CT_RAW" Source="FF5F95FA" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.AcceptedLine">
+        <Background Type="CT_RAW" Source="FF215D4A" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.AcceptedSimilarLine">
+        <Background Type="CT_RAW" Source="FF163F32" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.ConflictLine">
+        <Background Type="CT_RAW" Source="FF590D0D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.NotAcceptedLine">
+        <Background Type="CT_RAW" Source="FF181C18" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.DeletedNegativeSpace">
+        <Background Type="CT_RAW" Source="FFB1CE77" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.ConflictNegativeSpace">
+        <Background Type="CT_RAW" Source="FFDF2424" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.NegativeSpace">
+        <Background Type="CT_RAW" Source="FFD2D2D2" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.MarginIndicator">
+        <Background Type="CT_RAW" Source="FFCECECE" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.ConflictMarginIndicator">
+        <Background Type="CT_RAW" Source="FFDF2020" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.SelectionBox">
+        <Background Type="CT_RAW" Source="FF8CF1EF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CSS Keyword">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="CSS Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="CSS Selector">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="CSS Property Name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9EF5F3" />
+      </Color>
+      <Color Name="CSS Property Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="CSS String Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="HTML Attribute">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9EF5F3" />
+      </Color>
+      <Color Name="HTML Attribute Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="HTML Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="HTML Element Name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="HTML Entity">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00AEA8" />
+      </Color>
+      <Color Name="HTML Operator">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB4B4B4" />
+      </Color>
+      <Color Name="HTML Server-Side Script">
+        <Background Type="CT_RAW" Source="FFFFFFB3" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HTML Tag Delimiter">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="VBScript Keyword">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="VBScript Comment">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="VBScript Operator">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFB4B4B4" />
+      </Color>
+      <Color Name="VBScript Number">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFB5CEA8" />
+      </Color>
+      <Color Name="VBScript String">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="VBScript Identifier">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="VBScript Function Block Start">
+        <Background Type="CT_COLORINDEX" Source="00000001" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="FileLineClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="InstructionLineClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9B9B9B" />
+      </Color>
+      <Color Name="SourceLineClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFCFCFC" />
+      </Color>
+      <Color Name="SymbolLineClassificationFormat">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5F95FA" />
+      </Color>
+      <Color Name="CodeAnalysisCurrentStatementSelection">
+        <Background Type="CT_RAW" Source="FF501E00" />
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="CodeAnalysisWarningSelection">
+        <Background Type="CT_RAW" Source="FF825000" />
+        <Foreground Type="CT_RAW" Source="FF825000" />
+      </Color>
+      <Color Name="CodeAnalysisKeyEventSelection">
+        <Background Type="CT_RAW" Source="FF6E5000" />
+        <Foreground Type="CT_RAW" Source="FF6E5000" />
+      </Color>
+      <Color Name="CodeAnalysisLineTraceSelection">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FF333333" />
+      </Color>
+      <Color Name="OverviewMarginCollapsedRegion">
+        <Background Type="CT_RAW" Source="FFDCDCDC" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="OverviewMarginBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="OverviewMarginVisible">
+        <Background Type="CT_RAW" Source="FF04060D" />
+        <Foreground Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="OverviewMarginCaret">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF44F607" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/BookmarkInScrollBar">
+        <Background Type="CT_RAW" Source="FFC0C4C0" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/BreakpointInScrollBar">
+        <Background Type="CT_RAW" Source="FF903840" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek Background">
+        <Background Type="CT_RAW" Source="FF223842" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek Focused Border">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="Peek Background Unfocused">
+        <Background Type="CT_RAW" Source="FF111924" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek Label Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Block Structure Adornments">
+        <Background Type="CT_RAW" Source="FF00C4CC" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek Highlighted Text">
+        <Background Type="CT_RAW" Source="FF193476" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek Highlighted Text Unfocused">
+        <Background Type="CT_RAW" Source="FF111924" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="punctuation">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD1F7FF" />
+      </Color>
+      <Color Name="interface name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB8D7A3" />
+      </Color>
+      <Color Name="type parameter name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB8D7A3" />
+      </Color>
+      <Color Name="enum name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF15FF03" />
+      </Color>
+      <Color Name="module name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF33A2A1" />
+      </Color>
+      <Color Name="class name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF56E2" />
+      </Color>
+      <Color Name="delegate name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF33A2A1" />
+      </Color>
+      <Color Name="struct name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF0081" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/HighlightedDefinition">
+        <Background Type="CT_RAW" Source="FF552D7E" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE9D585" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF8CF1EF" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE9D585" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF89BB82" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFEDE0D1" />
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF8CF1EF" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFAEAEAE" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="RenameTrackingTag">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Edit and Continue">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFCA79EC" />
+      </Color>
+      <Color Name="RoslynActiveStatementTag">
+        <Background Type="CT_RAW" Source="FF274265" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/HighlightedWrittenReference">
+        <Background Type="CT_RAW" Source="FF552D7E" />
+        <Foreground Type="CT_RAW" Source="FF7A54A1" />
+      </Color>
+      <Color Name="brace matching">
+        <Background Type="CT_RAW" Source="FF067B7A" />
+        <Foreground Type="CT_AUTOMATIC" Source="00000000" />
+      </Color>
+      <Color Name="Stale Code">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9B9B9B" />
+      </Color>
+      <Color Name="RoslynRenameFixupTag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF008A00" />
+      </Color>
+      <Color Name="RoslynRenameFieldBackgroundAndBorderTag">
+        <Background Type="CT_RAW" Source="FFA6F1A6" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="RazorCode">
+        <Background Type="CT_RAW" Source="FF2B4159" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="RazorTagHelperAttribute">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF006763" />
+      </Color>
+      <Color Name="RazorTagHelperElement">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF006763" />
+      </Color>
+      <Color Name="HtmlClientTemplateValueFormatDefinition">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF00FF" />
+      </Color>
+      <Color Name="JSON Property Name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="LessCssVariableDeclarationClassificationFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC563BD" />
+      </Color>
+      <Color Name="LessCssVariableReferenceFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC563BD" />
+      </Color>
+      <Color Name="LessCssNamespaceReferenceFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="LessCssMixinDeclarationFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="LessCssMixinReferenceFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="LessCssKeywordFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD69C56" />
+      </Color>
+      <Color Name="ScssMixinDeclarationFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="ScssMixinReferenceFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="ScssVariableDeclarationClassificationFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC563BD" />
+      </Color>
+      <Color Name="ScssVariableReferenceFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC563BD" />
+      </Color>
+      <Color Name="TextMate.Classifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Test Summary - Default">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Test Summary - Header">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Test Summary - Label">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Test Summary - Stack">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Test Summary - No Source">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/ScrollBarComment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/FilteredScrollBarComment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/CommentMark">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/CommentHighlight">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Interactive Window Error Output">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.ConflictMismatchLine">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.WordDiffBoxConflict">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="mergeEditor.WordDiffBoxAccepted">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python class">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFDB31" />
+      </Color>
+      <Color Name="Python module">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF54FA49" />
+      </Color>
+      <Color Name="Python parameter">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC4C4C4" />
+      </Color>
+      <Color Name="Python function">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFA747FF" />
+      </Color>
+      <Color Name="Python documentation">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9DFF62" />
+      </Color>
+      <Color Name="Python regex">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python operator">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1FFFF" />
+      </Color>
+      <Color Name="Python grouping">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1FFFF" />
+      </Color>
+      <Color Name="Python comma">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1FFFF" />
+      </Color>
+      <Color Name="Python dot">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1FFFF" />
+      </Color>
+      <Color Name="Python builtin">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Black">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkRed">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkGreen">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkYellow">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkBlue">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkMagenta">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Python Interactive - DarkCyan">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Gray">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - DarkGray">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Red">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Green">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Yellow">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Blue">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Magenta">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - Cyan">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Python Interactive - White">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="FSharp.Function">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="FSharp.MutableVar">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD21C" />
+      </Color>
+      <Color Name="FSharp.Printf">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="FSharp.DisposableType">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="FSharp.DisposableLocalValue">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="FSharp.DisposableTopLevelValue">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Django template tag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppMacroSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF95A8E8" />
+      </Color>
+      <Color Name="CppEnumSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00A40B" />
+      </Color>
+      <Color Name="CppGlobalVariableSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFBD4000" />
+      </Color>
+      <Color Name="CppLocalVariableSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD5FF00" />
+      </Color>
+      <Color Name="CppParameterSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFE9400" />
+      </Color>
+      <Color Name="CppTypeSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF188B" />
+      </Color>
+      <Color Name="CppRefTypeSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppValueTypeSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppFunctionSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF267FC2" />
+      </Color>
+      <Color Name="CppMemberFunctionSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDA00E2" />
+      </Color>
+      <Color Name="CppMemberFieldSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00E0B0" />
+      </Color>
+      <Color Name="CppStaticMemberFunctionSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF701EDC" />
+      </Color>
+      <Color Name="CppStaticMemberFieldSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF882DFF" />
+      </Color>
+      <Color Name="CppPropertySemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF85C1" />
+      </Color>
+      <Color Name="CppEventSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF7C7C7C" />
+      </Color>
+      <Color Name="CppClassTemplateSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="CppGenericTypeSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppFunctionTemplateSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="CppNamespaceSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB0FF3D" />
+      </Color>
+      <Color Name="CppLabelSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF7B411" />
+      </Color>
+      <Color Name="CppUDLRawSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF109DF0" />
+      </Color>
+      <Color Name="CppUDLNumberSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF7ADFFF" />
+      </Color>
+      <Color Name="CppUDLStringSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF0060E2" />
+      </Color>
+      <Color Name="CppOperatorSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppMemberOperatorSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00FF9F" />
+      </Color>
+      <Color Name="CppNewDeleteSemanticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFF200" />
+      </Color>
+      <Color Name="HtmlClientTemplateSeparatorFormatDefinition">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="HtmlClientTemplateTagFormatDefinition">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF006400" />
+      </Color>
+      <Color Name="RoslynConflictTag">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="RoslynPreviewWarningTag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFF00" />
+      </Color>
+      <Color Name="RoslynRenameConflictTag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FF404040" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Inline Rename Field Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF006400" />
+      </Color>
+      <Color Name="string - escape character">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD68F" />
+      </Color>
+      <Color Name="keyword - control">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="operator - overloaded">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="record class name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="field name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="enum member name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00A40B" />
+      </Color>
+      <Color Name="constant name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF95A8E8" />
+      </Color>
+      <Color Name="local name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD400" />
+      </Color>
+      <Color Name="parameter name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="method name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD33E" />
+      </Color>
+      <Color Name="extension method name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="property name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="event name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="namespace name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD400" />
+      </Color>
+      <Color Name="label name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="regex - comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="regex - character class">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF979AE" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF979AE" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="regex - alternation">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="regex - text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD68F" />
+      </Color>
+      <Color Name="Peek History Selected">
+        <Background Type="CT_RAW" Source="FF00D2CB" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Peek History Hovered">
+        <Background Type="CT_RAW" Source="FF2FDCD7" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="OverviewMarginScrollButtons">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="A4A40052" />
+      </Color>
+      <Color Name="OverviewMarginScrollButtonsMouseOver">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFFF2790" />
+      </Color>
+      <Color Name="OverviewMarginScrollButtonsMouseDown">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="BraceCompletionClosingBrace">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Line Number">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFCE0067" />
+      </Color>
+		<Color Name="Selected Line Number">
+			<Background Type="CT_INVALID" Source="00000000" />
+			<Foreground Type="CT_RAW" Source="FF52FFFF" />
+		</Color>
+      <Color Name="Word Wrap Glyph">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="outlining.verticalrule">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF007379" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Caret (Primary)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Caret (Secondary)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="CppSuggestedActionFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="C/C++ User Keywords">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppControlKeywordSyntacticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF9090" />
+      </Color>
+      <Color Name="CppStringEscapeCharacterSyntacticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="CppStringDelimiterCharacterSyntacticTokenFormat">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE93DAC" />
+      </Color>
+      <Color Name="XML Doc Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF80FF80" />
+      </Color>
+      <Color Name="XML Doc Tag">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="PeekFormatDefinition/EOIMark">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="PeekFormatDefinition/PeekMark">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="MarkerFormatDefinition/VerticalHighlight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="UnnecessaryCodeDiagnostic">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="VSTU.MessageClassification">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+         <Color Name="ReSharper Error Unresolved">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Error Underlined">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Warning">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Dead Code">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Suggestion">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Non-Private Unused Members">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Hint">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item None">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Edit">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Edit Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Error Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Normal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Normal Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Question">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Question Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Warning">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Warning Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Todo Item Hyperlink">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Code Analysis Error Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Code Analysis Warning Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Code Analysis Suggestion Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Text to Delete in Config File">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Text to Insert in Config File">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Config File Conflict Warning">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Path Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language Background">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language String">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language Number">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Injected Language Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Parameter Name Hint">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFE4E4E4" />
+      </Color>
+      <Color Name="ReSharper Missing Construct Hint">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Resources Dispose Points">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Highlight">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Highlight Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Read Usage">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Read Usage Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Highlight Target">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Highlight Target Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Write Usage">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Write Usage Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Navigation Highlight">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Navigation Highlight Marker on Error Stripe">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Matched Brace">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Unmatched Brace">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Brace Outline">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Hyperlink">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Name or Signature Changed">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Smart Declaration">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Context Exit">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Usage of element under cursor">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF009403" />
+      </Color>
+      <Color Name="ReSharper Smart Paste">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Async Boundary">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Condition Element">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Default Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Constant Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Event Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Static Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Mutable Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Static Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Operator Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Namespace Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Format String Item">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Format String Item 2">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Matched Format String Item">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper String Escape Character 1">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper String Escape Character 2">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper LiveTemplates Current HotSpot">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper LiveTemplates Current HotSpot mirror">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper LiveTemplates Inactive HotSpot">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor Template Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Completion Replacement Range">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Class Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Struct Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Enum Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Interface Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Delegate Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Type Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Search with Pattern Editor Template Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Search with Pattern Editor Template Placeholder">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Search with Pattern Editor Template Undefined Placeholder">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Stack Trace Method">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Stack Trace Type">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Stack Trace Suspicious Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Stack Trace Path">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Stack Trace Hyperlink">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET Route Template Parameter">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET Route Template Token Substitution">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET Route Template">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="URL Segment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Invalid Character">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Set">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Group">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Escape Character 1">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Escape Character 2">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Matched Value">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Regex Matched Selection">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Rearrange Left/Right Code Hint">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Rearrange Up/Down Code Hint">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS id selector">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS value">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS class selector">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS pseudo selector">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS function">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS attribute name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper CSS property name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET MVC Action">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET MVC Area">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET MVC Controller">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET MVC View">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET MVC View Component">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper ASP.NET RunAt attribute">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML ID attribute">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Entity">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor CSS Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor CSS Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript XML Documentation Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Block-Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Block-Local Constant Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Local Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Unknown Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Template">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JsDoc Parameter or Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JsDoc Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JsDoc Type Annotation">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JsDoc Type Annotation Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JsDoc Type Definition">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper JavaScript Regex Border">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Json Property">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Json Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Interface Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Class Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Enum Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Module Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Alias Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Type Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Constrained Element Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper TypeScript Variable Declaration Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor JavaScript Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor JavaScript Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Constant Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL String Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Qualified Name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Instruction">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Code Label">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Target Code Label">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper IL Viewer Synchronization">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Fallback Attribute Name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Fallback Attribute Value">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Fallback Element Name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Fallback Tag Delimiter">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Entity 1">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper HTML Entity 2">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor HTML Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor HTML Attribute">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor HTML Tag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Escape Character 1">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Escape Character 2">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Constant Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Event Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Static Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Static Property Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Local Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Tuple Component Name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Mutable Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Accessor Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Static Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Extension Method Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Overloaded Operator">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Namespace Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Late Bound Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Class Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Static Class Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Record Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Struct Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Record Struct Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Enum Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Interface Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Delegate Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Type Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C# Overflow Checked Operation">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor C# Comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor C# Keyword">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper Template Editor C# Preprocessor Directive">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+         <Color Name="ReSharper C++ Class Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF188B" />
+      </Color>
+      <Color Name="ReSharper C++ Struct Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Enum Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Union Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Namespace Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB0FF3D" />
+      </Color>
+      <Color Name="ReSharper C++ Local Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Parameter Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Global Variable Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFBD4000" />
+      </Color>
+      <Color Name="ReSharper C++ Concept Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Class Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00E0B0" />
+      </Color>
+      <Color Name="ReSharper C++ Struct Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00E0B0" />
+      </Color>
+      <Color Name="ReSharper C++ Static Field Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Enum Enumerator Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00A40B" />
+      </Color>
+      <Color Name="ReSharper C++ Union Member Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Typedef Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFF188B" />
+      </Color>
+      <Color Name="ReSharper C++ Global Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF267FC2" />
+      </Color>
+      <Color Name="ReSharper C++ Member Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDA00E2" />
+      </Color>
+      <Color Name="ReSharper C++ Static Member Function Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF701EDC" />
+      </Color>
+      <Color Name="ReSharper C++ Overloaded Operator Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFEDEDED" />
+      </Color>
+      <Color Name="ReSharper C++ Template Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Dependent Name Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Preprocessor Macro Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF95A8E8" />
+      </Color>
+      <Color Name="ReSharper C++ Preprocessor Macro Parameter Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ UE4 Reflection Specifier Identifier">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Doxygen Command">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ String Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Character Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ Integer Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFCE0056" />
+      </Color>
+      <Color Name="ReSharper C++ Float Literal">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ UE4 Ini File Section">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ UE4 Ini File Key">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ReSharper C++ UE4 Ini File Value Property">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="data.tools.diff.remove.line">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="data.tools.diff.add.line">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="data.tools.diff.remove.word">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="data.tools.diff.add.word">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="keyword.qml">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="numeric.qml">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="string.qml">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="typename.qml">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="binding.qml">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Spelling Error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+	  <Color Name="axml - attribute name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF464FF" />
+      </Color>
+      <Color Name="axml - attribute quotes">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="axml - attribute value">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE7FF6C" />
+      </Color>
+      <Color Name="axml - cdata section">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="axml - comment">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF80FF80" />
+      </Color>
+      <Color Name="axml - delimiter">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDD2D83" />
+      </Color>
+      <Color Name="axml - entity reference">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD02FDC" />
+      </Color>
+      <Color Name="axml - name">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF0DEBFF" />
+      </Color>
+      <Color Name="axml - processing instruction">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF76FBBE" />
+      </Color>
+      <Color Name="axml - text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDFFDFF" />
+      </Color>
+      <Color Name="axml - resource url">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF89BBFF" />
+      </Color>
+      <Color Name="Dynamic Program Analysis Highlighter (Issue frame)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Command Window" GUID="{ee1be240-4e81-4beb-8eea-54322b6b1bf5}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="CommonControls" GUID="{c01072a1-a915-4abf-89b7-e2f9e8ec4c7f}">
+      <Color Name="FocusVisual">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Button">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="ButtonDefault">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="ButtonBorderDefault">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ButtonHover">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderHover">
+        <Background Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="ButtonDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ButtonBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ButtonFocused">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxTextHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxTextPressed">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxTextDisabled">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CheckBoxTextFocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBackgroundHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CheckBoxBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CheckBoxBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CheckBoxBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphPressed">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CheckBoxGlyphFocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxText">
+        <Background Type="CT_RAW" Source="FFD2F7FF" />
+      </Color>
+      <Color Name="ComboBoxSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBoxSeparatorDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBackgroundPressed">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ComboBoxBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextPressed">
+        <Background Type="CT_RAW" Source="FFD2F7FF" />
+      </Color>
+      <Color Name="ComboBoxSeparatorPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxBackgroundHover">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ComboBoxBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextHover">
+        <Background Type="CT_RAW" Source="FFF7007C" />
+      </Color>
+      <Color Name="ComboBoxSeparatorHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ComboBoxBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextFocused">
+        <Background Type="CT_RAW" Source="FFD2F7FF" />
+      </Color>
+      <Color Name="ComboBoxSeparatorFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxListItemBackgroundHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxListItemBorderHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxListItemTextHover">
+        <Background Type="CT_RAW" Source="FFD2F7FF" />
+      </Color>
+      <Color Name="ComboBoxListItemText">
+        <Background Type="CT_RAW" Source="FFD2F7FF" />
+      </Color>
+      <Color Name="ComboBoxListBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxListBorder">
+        <Background Type="CT_RAW" Source="CEAE0057" />
+      </Color>
+      <Color Name="ComboBoxSelection">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxListBackgroundShadow">
+        <Background Type="CT_RAW" Source="59B6005B" />
+      </Color>
+      <Color Name="ComboBoxTextInputSelection">
+        <Background Type="CT_RAW" Source="66B6005B" />
+      </Color>
+      <Color Name="InnerTabActiveBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InnerTabActiveBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InnerTabActiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabInactiveBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="InnerTabInactiveBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="InnerTabInactiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverBackground">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TextBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TextBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TextBoxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TextBoxBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TextBoxBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TextBoxTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="TextBoxBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TextBoxBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TextBoxTextFocused">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+    </Category>
+    <Category Name="CommonDocument" GUID="{72eb4027-f4ae-4b6c-9cc2-dfd5b49d9415}">
+      <Color Name="Page">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Caption">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TitleText">
+        <Background Type="CT_RAW" Source="FFA7B7D0" />
+      </Color>
+      <Color Name="HeaderText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SupportText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="HyperlinkPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF00ACAA" />
+      </Color>
+      <Color Name="ListItemGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridHeadingBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingHoverBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridHeadingHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridLine">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Divider">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ListItemBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ListItemBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ListItemText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemBorderHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ListItemBackgroundHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ListItemTextHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ListItemBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ListItemTextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemBorderSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ListItemBackgroundSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ListItemTextSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemBorderFocused">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ListItemBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ListItemTextFocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemBorderUnfocused">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ListItemBackgroundUnfocused">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ListItemTextUnfocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ListItemGlyphHover">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ListItemGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemGlyphFocused">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ListItemGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="TileViewBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="TileViewBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="TileViewText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TileViewBorderHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TileViewBackgroundHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TileViewTextHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TileViewBorderPressed">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TileViewBackgroundPressed">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TileViewTextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TileViewBorderSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TileViewBackgroundSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TileViewTextSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TileViewBorderFocused">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TileViewBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TileViewTextFocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TileViewBorderUnfocused">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="TileViewBackgroundUnfocused">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="TileViewTextUnfocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TileViewTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="InnerTabActiveBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabActiveBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabActiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabInactiveBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabInactiveBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabInactiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabInactiveHoverText">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="InnerTabInactiveTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="InnerTabActiveIndicator">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="InnerTabBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBackgroundDisabled">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBackgroundFocused">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBackgroundHover">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBackgroundPressed">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBorderDisabled">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBorderFocused">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBorderHover">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabBorderPressed">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabSelectedBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabSelectedBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InnerTabSelectedIndicator">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="InnerTabSelectedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="InnerTabTextFocused">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="InnerTabTextHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="InnerTabTextPressed">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="StatusBannerInfo">
+        <Background Type="CT_RAW" Source="1E1BA1E2" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="StatusBannerInfoBorder">
+        <Foreground Type="CT_RAW" Source="FF1BA1E2" />
+      </Color>
+      <Color Name="StatusBannerProgress">
+        <Background Type="CT_RAW" Source="1E94A6CA" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="StatusBannerProgressBorder">
+        <Foreground Type="CT_RAW" Source="FF94A6CA" />
+      </Color>
+      <Color Name="StatusBannerSuccess">
+        <Background Type="CT_RAW" Source="1E2E7D32" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="StatusBannerSuccessBorder">
+        <Foreground Type="CT_RAW" Source="FF2E7D32" />
+      </Color>
+      <Color Name="StatusBannerError">
+        <Background Type="CT_RAW" Source="1ED53230" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="StatusBannerErrorBorder">
+        <Foreground Type="CT_RAW" Source="FFD53230" />
+      </Color>
+      <Color Name="PageBackground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Container">
+        <Background Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="CommonDocumentCard" GUID="{2e129498-0d2d-43ca-94d6-c652c0132543}">
+      <Color Name="CardIllustrationFill1">
+        <Background Type="CT_RAW" Source="FF111924" />
+      </Color>
+      <Color Name="CardIllustrationFill2">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CardIllustrationFill3">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CardIllustrationFill4">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardPanel">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CardSupportText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CardHeaderText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CardPanelBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardPanelBorderHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardPanelBorderPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardTag">
+        <Background Type="CT_RAW" Source="FFECECEC" />
+      </Color>
+      <Color Name="CardTagBorder">
+        <Background Type="CT_RAW" Source="FFECECEC" />
+      </Color>
+      <Color Name="CardTagText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CardHyperlinkHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CardHyperlinkPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CardHyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CardShadow1">
+        <Background Type="CT_RAW" Source="0B000000" />
+      </Color>
+      <Color Name="CardShadow1Hover">
+        <Background Type="CT_RAW" Source="12000000" />
+      </Color>
+      <Color Name="CardShadow1Pressed">
+        <Background Type="CT_RAW" Source="12000000" />
+      </Color>
+      <Color Name="CardShadow2">
+        <Background Type="CT_RAW" Source="0D000000" />
+      </Color>
+      <Color Name="CardShadow2Hover">
+        <Background Type="CT_RAW" Source="0F000000" />
+      </Color>
+      <Color Name="CardShadow2Pressed">
+        <Background Type="CT_RAW" Source="0F000000" />
+      </Color>
+    </Category>
+    <Category Name="ConfigPage" GUID="{699a73b3-57e2-4754-9364-ee80d6852c2f}">
+      <Color Name="TabActive">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Watermark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="DescriptionPane">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="CosmosClientTools.2.2.1000.0" GUID="{6f796f8a-b3b5-49eb-9b25-cb59bd413caf}">
+      <Color Name="JobGraphBoder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="JobGraphFont">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobGraphSucceed">
+        <Background Type="CT_RAW" Source="FF2F843F" />
+      </Color>
+      <Color Name="JobGraphRunning">
+        <Background Type="CT_RAW" Source="FF3A617C" />
+      </Color>
+      <Color Name="JobGraphFailed">
+        <Background Type="CT_RAW" Source="FFAD1E2B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobGraphWait">
+        <Background Type="CT_RAW" Source="FF444444" />
+      </Color>
+      <Color Name="JobGraphLabel">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobGraphData">
+        <Background Type="CT_RAW" Source="FF26A9E0" />
+      </Color>
+      <Color Name="StageInfoTabItemSelectedHeader">
+        <Background Type="CT_RAW" Source="FF26A9E0" />
+      </Color>
+      <Color Name="StageInfoTabItemHeader">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="JobGraphBottom">
+        <Background Type="CT_RAW" Source="FF444545" />
+      </Color>
+      <Color Name="JobViewHeaderBorder">
+        <Background Type="CT_RAW" Source="FF404040" />
+      </Color>
+      <Color Name="JobViewHeader">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="ThemeIDColorKey">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobGraphWarning">
+        <Background Type="CT_RAW" Source="FFA36729" />
+      </Color>
+      <Color Name="JobViewDiagnoseHeader">
+        <Background Type="CT_RAW" Source="FF1B1B1C" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobViewDiagnoseHeaderBorder">
+        <Background Type="CT_RAW" Source="FF333337" />
+      </Color>
+      <Color Name="StreamPreviewCompositeData">
+        <Foreground Type="CT_RAW" Source="FFF39800" />
+      </Color>
+      <Color Name="JobGraphCollapseFrame">
+        <Background Type="CT_RAW" Source="FF9F9F9F" />
+      </Color>
+      <Color Name="JobGraphStreamFrame">
+        <Background Type="CT_RAW" Source="FF8D8D8D" />
+      </Color>
+      <Color Name="JobGraphStageFrame">
+        <Background Type="CT_RAW" Source="FFCBCBCB" />
+      </Color>
+      <Color Name="JobGraphBorder">
+        <Background Type="CT_RAW" Source="FF6C6C6C" />
+      </Color>
+      <Color Name="JobGraphStream">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="InfoBarBackground">
+        <Background Type="CT_RAW" Source="FFE0DEB0" />
+      </Color>
+      <Color Name="InfoBarBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="JobDiffExPropertyBackground">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobDiffExPropertyBorder">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="JobDiffExDiffResult">
+        <Background Type="CT_RAW" Source="FF4B1818" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DataSkewGridBackGround">
+        <Background Type="CT_RAW" Source="FF393939" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DataSkewInnerBackground">
+        <Background Type="CT_RAW" Source="FF252526" />
+      </Color>
+      <Color Name="DataSkewInfoHeader">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="JobDiffExDiffResultActive">
+        <Background Type="CT_RAW" Source="FF6F1313" />
+      </Color>
+      <Color Name="ValidationErrorForeground">
+        <Foreground Type="CT_RAW" Source="FFFF8080" />
+      </Color>
+      <Color Name="ValidationOKForeground">
+        <Foreground Type="CT_RAW" Source="FF32FF32" />
+      </Color>
+      <Color Name="ScriptText">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScriptKeyWord">
+        <Foreground Type="CT_RAW" Source="FF32D0FF" />
+      </Color>
+      <Color Name="ScriptComment">
+        <Foreground Type="CT_RAW" Source="FF32FF32" />
+      </Color>
+      <Color Name="ScriptIdentifier">
+        <Foreground Type="CT_RAW" Source="FFD0D000" />
+      </Color>
+      <Color Name="ScriptString">
+        <Foreground Type="CT_RAW" Source="FFFFA000" />
+      </Color>
+      <Color Name="ScriptNumber">
+        <Foreground Type="CT_RAW" Source="FFB5CEA8" />
+      </Color>
+      <Color Name="ScriptClassName">
+        <Foreground Type="CT_RAW" Source="FF4EC9B0" />
+      </Color>
+      <Color Name="ScriptError">
+        <Foreground Type="CT_RAW" Source="FFFF8080" />
+      </Color>
+      <Color Name="ScriptBuiltInFunction">
+        <Foreground Type="CT_RAW" Source="FFFF50FF" />
+      </Color>
+      <Color Name="ScriptParameter">
+        <Foreground Type="CT_RAW" Source="FFD0D000" />
+      </Color>
+      <Color Name="ScriptPreprocess">
+        <Foreground Type="CT_RAW" Source="FFA0A0A0" />
+      </Color>
+      <Color Name="JobViewHeaderText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ValidationBoxBackground">
+        <Background Type="CT_RAW" Source="FF252526" />
+      </Color>
+      <Color Name="InfoBarForeground">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HyperlinkForeground">
+        <Background Type="CT_RAW" Source="FF252526" />
+        <Foreground Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="JobGraphLegendBackground">
+        <Background Type="CT_RAW" Source="FF252526" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobDiffExResultDifferent">
+        <Foreground Type="CT_RAW" Source="FFFF8080" />
+      </Color>
+      <Color Name="JobDiffExResultMissingValue">
+        <Foreground Type="CT_RAW" Source="FF8080FF" />
+      </Color>
+      <Color Name="HeatMapAverageNegative3SD">
+        <Background Type="CT_RAW" Source="FF293955" />
+      </Color>
+      <Color Name="HeatMapAverageNegative2SD">
+        <Background Type="CT_RAW" Source="FF364E6F" />
+      </Color>
+      <Color Name="HeatMapAverageNegativeSD">
+        <Background Type="CT_RAW" Source="FF5C7199" />
+      </Color>
+      <Color Name="HeatMapAverage">
+        <Background Type="CT_RAW" Source="FF666666" />
+      </Color>
+      <Color Name="HeatMapAverageSD">
+        <Background Type="CT_RAW" Source="FFAA894F" />
+      </Color>
+      <Color Name="HeatMapAverage2SD">
+        <Background Type="CT_RAW" Source="FF8E5726" />
+      </Color>
+      <Color Name="HeatMapAverage3SD">
+        <Background Type="CT_RAW" Source="FF72401C" />
+      </Color>
+      <Color Name="JobGraphBottomOriginal">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="JobViewDiagnosticsTabHeaderIcon">
+        <Background Type="CT_RAW" Source="FF68501A" />
+      </Color>
+      <Color Name="JobViewErrorTabHeaderIcon">
+        <Background Type="CT_RAW" Source="FF5B031E" />
+      </Color>
+      <Color Name="JobViewErrorTabHeaderTopLine">
+        <Background Type="CT_RAW" Source="FFAD1F2B" />
+      </Color>
+      <Color Name="JobViewWarning">
+        <Background Type="CT_RAW" Source="FFF5A720" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobViewWarningHeaderPanel">
+        <Background Type="CT_RAW" Source="FF555555" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="JobViewWarningItemPanelPrimary">
+        <Background Type="CT_RAW" Source="FF3B3B3F" />
+        <Foreground Type="CT_RAW" Source="FF64B9FF" />
+      </Color>
+      <Color Name="JobViewWarningItemPanelSecondary">
+        <Background Type="CT_RAW" Source="FF333337" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="ExtractScriptBuilderHeader">
+        <Background Type="CT_RAW" Source="FF252526" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ExtractScriptBuilderHeaderMouseOn">
+        <Background Type="CT_RAW" Source="FF8E5726" />
+      </Color>
+    </Category>
+    <Category Name="CpuUsageTool" GUID="{02071ec8-0cf0-4822-af30-9f001537e7eb}">
+      <Color Name="CallerCalleeFunctionGroupBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CallerCalleeFunctionGroupBorder">
+        <Background Type="CT_RAW" Source="FFB1B9C9" />
+      </Color>
+      <Color Name="CallerCalleeFunctionBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CallerCalleeFunctionBorder">
+        <Background Type="CT_RAW" Source="FFB1B9C9" />
+      </Color>
+      <Color Name="CallerCalleeFunctionBackgroundHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CallerCalleeFunctionBorderHover">
+        <Background Type="CT_RAW" Source="FFB1B9C9" />
+      </Color>
+      <Color Name="CallerCalleeFunctionHighUsageBackground">
+        <Background Type="CT_RAW" Source="FFAD1C2B" />
+      </Color>
+      <Color Name="CallerCalleeFunctionHighUsageBorder">
+        <Background Type="CT_RAW" Source="FFFF7971" />
+      </Color>
+      <Color Name="CallerCalleeFunctionHighUsageBackgroundHover">
+        <Background Type="CT_RAW" Source="FFD91F32" />
+      </Color>
+      <Color Name="CallerCalleeFunctionHighUsageBorderHover">
+        <Background Type="CT_RAW" Source="FFFF7971" />
+      </Color>
+      <Color Name="CallerCalleeFunctionLowUsageBackground">
+        <Background Type="CT_RAW" Source="FF341B1B" />
+      </Color>
+      <Color Name="CallerCalleeFunctionLowUsageBorder">
+        <Background Type="CT_RAW" Source="FFFF7971" />
+      </Color>
+      <Color Name="CallerCalleeFunctionLowUsageBackgroundHover">
+        <Background Type="CT_RAW" Source="FF4B2B2B" />
+      </Color>
+      <Color Name="CallerCalleeFunctionLowUsageBorderHover">
+        <Background Type="CT_RAW" Source="FFFF7971" />
+      </Color>
+      <Color Name="CallerCalleeTitleText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CallerCalleeSubTitleText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="FlatFunctionsUsageBarBackground">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="TreeGridCellLabelText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+    </Category>
+    <Category Name="Data Source Designer" GUID="{3ffb3681-9b54-42b2-81d5-52453adf56a6}">
+      <Color Name="Surface">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Shape">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ShapeTitle">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedShapeTitle">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ActiveShapeTitle">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedShapeBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ShapeBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Grid">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="RelationLine">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="RelationLabel">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedRelationLine">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+    </Category>
+    <Category Name="Database Designer" GUID="{4c889e8a-2bbb-4dc8-ae21-b1e4799d7631}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Text Annotation">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Diagram Background">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Table Title Bar">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="DataGrid" GUID="{925b1226-26e5-47e0-9d0d-673301e557fb}">
+      <Color Name="HeaderBackground">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="HeaderDown">
+        <Background Type="CT_RAW" Source="FF606060" />
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="RowBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="CellSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CellSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="HeaderBorder">
+        <Background Type="CT_RAW" Source="FFDFE0E1" />
+      </Color>
+      <Color Name="HeaderMouseOver">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="AAA5B4B1" />
+      </Color>
+      <Color Name="HeaderMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="GridLine">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="WatermarkSelectedForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColumnHeaderDisabledText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+    </Category>
+    <Category Name="DataTips" GUID="{f7b7b222-e186-48df-a5ee-174e8129891b}">
+      <Color Name="TopTipText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="BkgTipText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="TopTipHighlightText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="BkgTipHighlightText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="DebugLocation" GUID="{b20c0001-0836-4535-a5e8-96e595b1f094}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ChangedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="DetailsView" GUID="{a128c60e-947c-4f26-95c9-fb4b3d53547f}">
+      <Color Name="CommandBarMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CommandBarHoverOverSelected">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+    </Category>
+    <Category Name="Diagnostics" GUID="{6f4c1845-5111-4f31-b204-47cb6a466ee8}">
+      <Color Name="AdvancedListItemLinkSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="AdvancedListItemHover">
+        <Background Type="CT_RAW" Source="FF353535" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AdvancedListItemLinkHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="AdvancedListItem">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="AdvancedListItemLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="AdvancedListItemSelected">
+        <Background Type="CT_RAW" Source="FF3F3F3F" />
+        <Foreground Type="CT_RAW" Source="FFE2EDFA" />
+      </Color>
+      <Color Name="ControlSelectedItem">
+        <Background Type="CT_RAW" Source="FF3F3F3F" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ControlHeader">
+        <Background Type="CT_RAW" Source="FF3E424F" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ControlContent">
+        <Background Type="CT_RAW" Source="FF2C2C2C" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TargetBackground">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="TargetBackgroundHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="TargetBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TargetBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TargetBorderHover">
+        <Background Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="TargetBorderPressed">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="Divider">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ToolBackground">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ToolBackgroundHover">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ToolBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ToolBorderHover">
+        <Background Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="ButtonBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ButtonBorderDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ButtonTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="TargetHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowSplitBarBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+    </Category>
+    <Category Name="DiagnosticsHub" GUID="{f8a8b2a5-dd35-43f6-a382-fd6a61325c22}">
+      <Color Name="Border">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="GraphLine">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="RulerSlider">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="RulerSliderActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="RulerTickmark">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="SwimlaneBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="ToolbarTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="GraphCursor">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="GraphScale">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="ToolbarBackgroundHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+      </Color>
+      <Color Name="ToolbarBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+    </Category>
+    <Category Name="Dialogs and Tool Windows" GUID="{1f987c00-e7c4-4869-8a17-23fd602268b0}">
+      <Color Name="ToolTip">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFE8F4FF" />
+      </Color>
+      <Color Name="ToolTipBorder">
+        <Background Type="CT_RAW" Source="FF25456D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Editor Tooltip" GUID="{a9a5637f-b2a8-422e-8fb5-dfb4625f0111}">
+      <Color Name="Plain Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="Environment" GUID="{624ed9c3-bdfd-41fa-96c3-7c824ea32e3d}">
+      <Color Name="ActiveBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ActiveCaption">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="AppWorkspace">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ButtonFace">
+        <Background Type="CT_RAW" Source="FF5E003A" />
+      </Color>
+      <Color Name="ButtonHighlight">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="ButtonShadow">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ButtonText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CaptionText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GrayText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Highlight">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="HighlightText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="InactiveBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="InactiveCaption">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="InactiveCaptionText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="InfoBackground">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="InfoText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="Menu">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="MenuText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScrollBar">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ThreeDDarkShadow">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ThreeDFace">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ThreeDHighlight">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="ThreeDLightShadow">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ThreeDShadow">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Window">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="WindowFrame">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="WindowText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="AutoHideTabText">
+        <Background Type="CT_RAW" Source="FF169AFF" />
+      </Color>
+      <Color Name="AutoHideTabBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="AutoHideTabBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="AutoHideTabBorder">
+        <Background Type="CT_RAW" Source="9F4289FF" />
+      </Color>
+      <Color Name="AutoHideTabMouseOverText">
+        <Background Type="CT_RAW" Source="FF68BEFF" />
+      </Color>
+      <Color Name="AutoHideTabMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="AutoHideTabMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="AutoHideTabMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFFF1F79" />
+      </Color>
+      <Color Name="AutoHideResizeGrip">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ClassDesignerClassCompartment">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ClassDesignerClassHeaderBackground">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="ClassDesignerCommentBorder">
+        <Background Type="CT_RAW" Source="FFCCCC66" />
+      </Color>
+      <Color Name="ClassDesignerCommentShapeBackground">
+        <Background Type="CT_RAW" Source="FFFFFFCC" />
+      </Color>
+      <Color Name="ClassDesignerCommentText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ClassDesignerCompartmentSeparator">
+        <Background Type="CT_RAW" Source="FFD2D2D2" />
+      </Color>
+      <Color Name="ClassDesignerConnectionRouteBorder">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ClassDesignerDefaultConnection">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeTitleBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeBorder">
+        <Background Type="CT_RAW" Source="FF62001E" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeSubtitle">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ClassDesignerDefaultShapeTitle">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ClassDesignerDelegateCompartment">
+        <Background Type="CT_RAW" Source="FFF7F0F0" />
+      </Color>
+      <Color Name="ClassDesignerDelegateHeader">
+        <Background Type="CT_RAW" Source="FFEDDADC" />
+      </Color>
+      <Color Name="ClassDesignerDiagramBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ClassDesignerEmphasisBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ClassDesignerEnumHeader">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="ClassDesignerFieldAssociation">
+        <Background Type="CT_RAW" Source="FF266035" />
+      </Color>
+      <Color Name="ClassDesignerGradientEnd">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ClassDesignerInheritance">
+        <Background Type="CT_RAW" Source="FF716F64" />
+      </Color>
+      <Color Name="ClassDesignerInterfaceHeader">
+        <Background Type="CT_RAW" Source="FFE6F0DB" />
+      </Color>
+      <Color Name="ClassDesignerInterfaceCompartment">
+        <Background Type="CT_RAW" Source="FFF3F7F0" />
+      </Color>
+      <Color Name="ClassDesignerLasso">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ClassDesignerLollipop">
+        <Background Type="CT_RAW" Source="FF716F64" />
+      </Color>
+      <Color Name="ClassDesignerPropertyAssociation">
+        <Background Type="CT_RAW" Source="FFB0764F" />
+      </Color>
+      <Color Name="ClassDesignerReferencedAssemblyBorder">
+        <Background Type="CT_RAW" Source="FF716F64" />
+      </Color>
+      <Color Name="ClassDesignerResizingShapeBorder">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ClassDesignerShapeBorder">
+        <Background Type="CT_RAW" Source="FF716F64" />
+      </Color>
+      <Color Name="ClassDesignerShapeShadow">
+        <Background Type="CT_RAW" Source="FFD8D8D8" />
+      </Color>
+      <Color Name="ClassDesignerTempConnection">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ClassDesignerTypedef">
+        <Background Type="CT_RAW" Source="FF716F64" />
+      </Color>
+      <Color Name="ClassDesignerTypedefHeader">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="ClassDesignerUnresolvedText">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="ClassDesignerVBModuleCompartment">
+        <Background Type="CT_RAW" Source="FFF8F4E9" />
+      </Color>
+      <Color Name="ClassDesignerVBModuleHeader">
+        <Background Type="CT_RAW" Source="FFF0E9D2" />
+      </Color>
+      <Color Name="ComboBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxDisabledBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxDisabledGlyph">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxPopupBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxPopupBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="ComboBoxPopupBorder">
+        <Background Type="CT_RAW" Source="4852FFFF" />
+      </Color>
+      <Color Name="CommandBarCheckBox">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMenuBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="8404071F" />
+      </Color>
+      <Color Name="CommandBarMenuBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="8E04071F" />
+      </Color>
+      <Color Name="CommandBarMenuBorder">
+        <Background Type="CT_RAW" Source="6CC70050" />
+      </Color>
+      <Color Name="CommandBarMenuIconBackground">
+        <Background Type="CT_RAW" Source="8804071F" />
+      </Color>
+      <Color Name="CommandBarMenuMouseOverSubmenuGlyph">
+        <Background Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="CommandBarMenuSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarMenuSubmenuGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMouseDownBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="CommandBarMouseDownBackgroundMiddle">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="CommandBarMouseDownBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="CommandBarMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF4B0060" />
+      </Color>
+      <Color Name="CommandBarMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="FF4B0060" />
+      </Color>
+      <Color Name="CommandBarMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="FF4B0060" />
+      </Color>
+      <Color Name="CommandBarMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF4B0060" />
+      </Color>
+      <Color Name="CommandBarOptionsBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarOptionsGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseDownBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseDownBackgroundMiddle">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseDownBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFFF30A5" />
+      </Color>
+      <Color Name="CommandBarSelectedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarToolBarBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarToolBarSeparator">
+        <Background Type="CT_RAW" Source="FF222222" />
+      </Color>
+      <Color Name="CommandShelfBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandShelfBackgroundGradientMiddle">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandShelfBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandShelfHighlightGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandShelfHighlightGradientMiddle">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandShelfHighlightGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DiagReportBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DiagReportSecondaryPageHeader">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="DiagReportSecondaryPageSubtitle">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DiagReportSecondaryPageTitle">
+        <Background Type="CT_RAW" Source="FF4E6685" />
+      </Color>
+      <Color Name="DiagReportSummaryPageHeader">
+        <Background Type="CT_RAW" Source="FF4E6685" />
+      </Color>
+      <Color Name="DiagReportSummaryPageSubtitle">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="DiagReportSummaryPageTitle">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DiagReportText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DockTargetBackground">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="DockTargetBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DockTargetButtonBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DockTargetButtonBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DockTargetButtonBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DockTargetGlyphBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DockTargetGlyphBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DockTargetGlyphArrow">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DockTargetGlyphBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DropDownBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DropDownDisabledBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DropDownDisabledGlyph">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DropDownGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="DropDownMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DropDownMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFF7007C" />
+      </Color>
+      <Color Name="DropDownMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DropDownPopupBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="DropDownPopupBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="DropDownPopupBorder">
+        <Background Type="CT_RAW" Source="8BEE0078" />
+      </Color>
+      <Color Name="DropShadowBackground">
+        <Background Type="CT_RAW" Source="7E000321" />
+      </Color>
+      <Color Name="EnvironmentBackgroundGradientMiddle1">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EnvironmentBackgroundGradientMiddle2">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EnvironmentBackgroundTexture1">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EnvironmentBackgroundTexture2">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ExtensionManagerStarHighlight1">
+        <Background Type="CT_RAW" Source="FFFF8C00" />
+      </Color>
+      <Color Name="ExtensionManagerStarHighlight2">
+        <Background Type="CT_RAW" Source="FFFF8C00" />
+      </Color>
+      <Color Name="ExtensionManagerStarInactive1">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ExtensionManagerStarInactive2">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="FileTabHotBorder">
+        <Background Type="CT_RAW" Source="999C3871" />
+      </Color>
+      <Color Name="FileTabHotText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabHotGlyph">
+        <Background Type="CT_RAW" Source="FFD0E6F5" />
+      </Color>
+      <Color Name="FileTabInactiveGradientTop">
+        <Background Type="CT_RAW" Source="FF5B0034" />
+      </Color>
+      <Color Name="FileTabInactiveGradientBottom">
+        <Background Type="CT_RAW" Source="FF5B0034" />
+      </Color>
+      <Color Name="FileTabInactiveDocumentBorderBackground">
+        <Background Type="CT_RAW" Source="FF5B0034" />
+      </Color>
+      <Color Name="FileTabInactiveDocumentBorderEdge">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="FileTabInactiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabLastActiveGradientTop">
+        <Background Type="CT_RAW" Source="FFA400BD" />
+      </Color>
+      <Color Name="FileTabLastActiveGradientMiddle1">
+        <Background Type="CT_RAW" Source="FFA400BD" />
+      </Color>
+      <Color Name="FileTabLastActiveGradientMiddle2">
+        <Background Type="CT_RAW" Source="FFA400BD" />
+      </Color>
+      <Color Name="FileTabLastActiveGradientBottom">
+        <Background Type="CT_RAW" Source="FFA400BD" />
+      </Color>
+      <Color Name="FileTabLastActiveDocumentBorderBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="FileTabLastActiveDocumentBorderEdge">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="FileTabLastActiveText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabLastActiveGlyph">
+        <Background Type="CT_RAW" Source="FFD0E6F5" />
+      </Color>
+      <Color Name="FileTabSelectedGradientMiddle1">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="FileTabSelectedGradientMiddle2">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="NewProjectBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="NewProjectProviderHoverForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NewProjectProviderHoverBegin">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectProviderHoverMiddle1">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectProviderHoverMiddle2">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectProviderHoverEnd">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectProviderInactiveForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NewProjectProviderInactiveBegin">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectProviderInactiveEnd">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="NewProjectItemSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="NewProjectItemInactiveBegin">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectItemInactiveEnd">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NewProjectItemInactiveBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageContentExpanderChevron">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PageContentExpanderSeparator">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageSideBarExpanderBody">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="PageSideBarExpanderChevron">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PageSideBarExpanderHeader">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageSideBarExpanderHeaderHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageSideBarExpanderHeaderPressed">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageSideBarExpanderSeparator">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PageSideBarExpanderText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScrollBarArrowBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarArrowDisabledBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarArrowMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarArrowPressedBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarDisabledBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ScrollBarThumbBackground">
+        <Background Type="CT_RAW" Source="A4A40052" />
+      </Color>
+      <Color Name="ScrollBarThumbBorder">
+        <Background Type="CT_RAW" Source="C2BE005F" />
+      </Color>
+      <Color Name="ScrollBarThumbGlyph">
+        <Background Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="ScrollBarThumbMouseOverBackground">
+        <Background Type="CT_RAW" Source="CCBE005F" />
+      </Color>
+      <Color Name="ScrollBarThumbPressedBackground">
+        <Background Type="CT_RAW" Source="FFDD006C" />
+      </Color>
+      <Color Name="SearchBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SearchBoxBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SearchBoxMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxPressedBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SearchBoxPressedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageButtonBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StartPageButtonMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonMouseOverBackgroundMiddle1">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonMouseOverBackgroundMiddle2">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonPinned">
+        <Background Type="CT_RAW" Source="FFF30506" />
+      </Color>
+      <Color Name="StartPageButtonPinDown">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonPinHover">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageButtonUnpinned">
+        <Background Type="CT_RAW" Source="FFF30506" />
+      </Color>
+      <Color Name="StartPageButtonText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageButtonTextHover">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="StartPageSelectedItemBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageSelectedItemStroke">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageTabBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageTabBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageTabMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageTabMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageTextBody">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageTextBodySelected">
+        <Background Type="CT_RAW" Source="FFF30506" />
+      </Color>
+      <Color Name="StartPageTextBodyUnselected">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageTextControlLinkSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageTextControlLinkSelectedHover">
+        <Background Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="StartPageTextDate">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageTextHeading">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StartPageTextHeadingMouseOver">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="StartPageTextHeadingSelected">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageTextSubHeading">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StartPageTextSubHeadingMouseOver">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="StartPageTextSubHeadingSelected">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageUnselectedItemBackgroundBegin">
+        <Background Type="CT_RAW" Source="FF3F3F3F" />
+      </Color>
+      <Color Name="StartPageUnselectedItemBackgroundEnd">
+        <Background Type="CT_RAW" Source="FF464646" />
+      </Color>
+      <Color Name="StartPageUnselectedItemStroke">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StatusBarText">
+        <Background Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="TitleBarActiveGradientMiddle1">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarActiveGradientMiddle2">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolboxSelectedHeadingBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolboxSelectedHeadingMiddle1">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolboxSelectedHeadingMiddle2">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolboxSelectedHeadingEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowButtonInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonInactiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFCE0056" />
+      </Color>
+      <Color Name="ToolWindowButtonDownInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ToolWindowButtonActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverActiveGlyph">
+        <Background Type="CT_RAW" Source="FFCE0056" />
+      </Color>
+      <Color Name="ToolWindowButtonDownActiveGlyph">
+        <Background Type="CT_RAW" Source="FFCE0056" />
+      </Color>
+      <Color Name="ToolWindowContentTabGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowContentTabGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowFloatingFrame">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ToolWindowTabMouseOverBackgroundBegin">
+        <Background Type="CT_RAW" Source="00003459" />
+      </Color>
+      <Color Name="ToolWindowTabMouseOverBackgroundEnd">
+        <Background Type="CT_RAW" Source="00003459" />
+      </Color>
+      <Color Name="ToolWindowTabMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToolWindowTabMouseOverText">
+        <Background Type="CT_RAW" Source="FF0BFEFC" />
+      </Color>
+      <Color Name="VizSurfaceBrownDark">
+        <Background Type="CT_RAW" Source="FF705829" />
+      </Color>
+      <Color Name="VizSurfaceBrownLight">
+        <Background Type="CT_RAW" Source="FFB0A781" />
+      </Color>
+      <Color Name="VizSurfaceBrownMedium">
+        <Background Type="CT_RAW" Source="FFA19667" />
+      </Color>
+      <Color Name="VizSurfaceDarkGoldDark">
+        <Background Type="CT_RAW" Source="FFA79432" />
+      </Color>
+      <Color Name="VizSurfaceDarkGoldLight">
+        <Background Type="CT_RAW" Source="FFD0D4B7" />
+      </Color>
+      <Color Name="VizSurfaceDarkGoldMedium">
+        <Background Type="CT_RAW" Source="FFBFC749" />
+      </Color>
+      <Color Name="VizSurfaceGoldDark">
+        <Background Type="CT_RAW" Source="FFCAB22D" />
+      </Color>
+      <Color Name="VizSurfaceGoldLight">
+        <Background Type="CT_RAW" Source="FFFBF7C8" />
+      </Color>
+      <Color Name="VizSurfaceGoldMedium">
+        <Background Type="CT_RAW" Source="FFE2E442" />
+      </Color>
+      <Color Name="VizSurfaceGreenDark">
+        <Background Type="CT_RAW" Source="FF5D8039" />
+      </Color>
+      <Color Name="VizSurfaceGreenLight">
+        <Background Type="CT_RAW" Source="FFB1C97B" />
+      </Color>
+      <Color Name="VizSurfaceGreenMedium">
+        <Background Type="CT_RAW" Source="FF9FB861" />
+      </Color>
+      <Color Name="VizSurfacePlumDark">
+        <Background Type="CT_RAW" Source="FF8E5478" />
+      </Color>
+      <Color Name="VizSurfacePlumLight">
+        <Background Type="CT_RAW" Source="FFE2B1CD" />
+      </Color>
+      <Color Name="VizSurfacePlumMedium">
+        <Background Type="CT_RAW" Source="FFCB98B6" />
+      </Color>
+      <Color Name="VizSurfaceRedDark">
+        <Background Type="CT_RAW" Source="FFAD1C2B" />
+      </Color>
+      <Color Name="VizSurfaceRedLight">
+        <Background Type="CT_RAW" Source="FFFF9F99" />
+      </Color>
+      <Color Name="VizSurfaceRedMedium">
+        <Background Type="CT_RAW" Source="FFFF7971" />
+      </Color>
+      <Color Name="VizSurfaceSoftBlueDark">
+        <Background Type="CT_RAW" Source="FF7891AF" />
+      </Color>
+      <Color Name="VizSurfaceSoftBlueLight">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="VizSurfaceSoftBlueMedium">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="VizSurfaceSteelBlueDark">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="VizSurfaceSteelBlueLight">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="VizSurfaceSteelBlueMedium">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="VizSurfaceStrongBlueDark">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="VizSurfaceStrongBlueLight">
+        <Background Type="CT_RAW" Source="FFDBE5F5" />
+      </Color>
+      <Color Name="VizSurfaceStrongBlueMedium">
+        <Background Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="AccentBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="AccentDark">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="AccentLight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="AccentMedium">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="AccentPale">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="CommandBarDragHandle">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="CommandBarDragHandleShadow">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="CommandBarGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarGradientMiddle">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CommandBarHoverOverSelected">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CommandBarHoverOverSelectedIcon">
+        <Background Type="CT_RAW" Source="FF4B0060" />
+      </Color>
+      <Color Name="CommandBarHoverOverSelectedIconBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="CommandBarSelected">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarShadow">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarTextActive">
+        <Background Type="CT_RAW" Source="FF169AFF" />
+      </Color>
+      <Color Name="CommandBarTextHover">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="CommandBarTextInactive">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CommandBarTextSelected">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CompletionBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ControlEditHintText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ControlEditRequiredBackground">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ControlEditRequiredHintText">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="ControlLinkText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ControlLinkTextHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ControlLinkTextPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ControlOutline">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveBorder">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveHighlight">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveHighlightText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DebuggerDataTipActiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveHighlight">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveHighlightText">
+        <Background Type="CT_RAW" Source="FF7A7A7A" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DebuggerDataTipInactiveText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="DesignerBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DesignerSelectionDots">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="DesignerTray">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DesignerWatermark">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="EditorExpansionBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EditorExpansionFill">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="EditorExpansionLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="EditorExpansionText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="EnvironmentBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EnvironmentBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="EnvironmentBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabBorder">
+        <Background Type="CT_RAW" Source="002B0018" />
+      </Color>
+      <Color Name="FileTabChannelBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabGradientDark">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabGradientLight">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabSelectedBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="FileTabSelectedBorder">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="FileTabSelectedText">
+        <Background Type="CT_RAW" Source="FFBDFCFF" />
+      </Color>
+      <Color Name="FileTabText">
+        <Background Type="CT_RAW" Source="FFBDFCFF" />
+      </Color>
+      <Color Name="FormSmartTagActionTagBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="FormSmartTagActionTagFill">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FormSmartTagObjectTagBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="FormSmartTagObjectTagFill">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GridHeadingBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="GridHeadingText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridLine">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpHowDoIPaneBackground">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="HelpHowDoIPaneLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HelpHowDoIPaneText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpHowDoITaskBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="HelpHowDoITaskLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HelpHowDoITaskText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchFrameBackground">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="HelpSearchFrameText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchBorder">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="HelpSearchFilterText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchFilterBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="HelpSearchFilterBorder">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="HelpSearchProviderUnselectedBackground">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="HelpSearchProviderUnselectedText">
+        <Background Type="CT_RAW" Source="FF051B40" />
+      </Color>
+      <Color Name="HelpSearchProviderSelectedBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="HelpSearchProviderSelectedText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchProviderIcon">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchResultLinkSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HelpSearchResultLinkUnselected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HelpSearchResultSelectedBackground">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="HelpSearchResultSelectedText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="HelpSearchText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="HelpSearchPanelRules">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="MdiClientBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelGradientDark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="PanelGradientLight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="PanelHoverOverCloseBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PanelHoverOverCloseFill">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="PanelHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PanelHyperlinkHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="PanelHyperlinkPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PanelSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelSubGroupSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PanelTitleBar">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="PanelTitleBarText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PanelTitleBarUnselected">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ProjectDesignerBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerBorderOutside">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerBorderInside">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerContentsBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerTabBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerTabBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerTabSelectedInsideBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ProjectDesignerTabSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ProjectDesignerTabSelectedHighlight1">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ProjectDesignerTabSelectedHighlight2">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ProjectDesignerTabSelectedBackground">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ProjectDesignerTabSepBottomGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ProjectDesignerTabSepBottomGradientEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ProjectDesignerTabSepTopGradientBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ProjectDesignerTabSepTopGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScreenTipBorder">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ScreenTipBackground">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ScreenTipText">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SideBarBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SideBarGradientDark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SideBarGradientLight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SideBarText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SmartTagBorder">
+        <Background Type="CT_RAW" Source="FFE5C365" />
+      </Color>
+      <Color Name="SmartTagFill">
+        <Background Type="CT_RAW" Source="FFFFEFBB" />
+      </Color>
+      <Color Name="SmartTagHoverBorder">
+        <Background Type="CT_RAW" Source="FFE5C365" />
+      </Color>
+      <Color Name="SmartTagHoverFill">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="SmartTagHoverText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="SmartTagText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Snaplines">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SnaplinesPadding">
+        <Background Type="CT_RAW" Source="FFD5DEF0" />
+      </Color>
+      <Color Name="SnaplinesTextBaseline">
+        <Background Type="CT_RAW" Source="FFE122DF" />
+      </Color>
+      <Color Name="SortBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SortText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TaskListGridLines">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="TitleBarActive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarActiveGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarActiveGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarActiveText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TitleBarInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarInactiveGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarInactiveGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarInactiveText">
+        <Background Type="CT_RAW" Source="FFD0D0D0" />
+      </Color>
+      <Color Name="ToolboxBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxDivider">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolboxGradientDark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxGradientLight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxHeadingAccent">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxHeadingBegin">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxHeadingEnd">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxIconHighlight">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolboxIconShadow">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToolWindowBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowBorder">
+        <Background Type="CT_RAW" Source="49C70050" />
+      </Color>
+      <Color Name="ToolWindowButtonDown">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverActive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverActiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowButtonHoverInactiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolWindowTabSelectedTab">
+        <Background Type="CT_RAW" Source="00003459" />
+      </Color>
+      <Color Name="ToolWindowTabBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowTabGradientBegin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowTabGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowTabText">
+        <Background Type="CT_RAW" Source="FFD0D0D0" />
+      </Color>
+      <Color Name="ToolWindowTabSelectedText">
+        <Background Type="CT_RAW" Source="FFD5288A" />
+      </Color>
+      <Color Name="WizardOrientationPanelBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WizardOrientationPanelText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="SplashScreenBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="FileTabSelectedGradientTop">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="FileTabSelectedGradientBottom">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="FileTabHotGradientTop">
+        <Background Type="CT_RAW" Source="999C3871" />
+      </Color>
+      <Color Name="FileTabHotGradientBottom">
+        <Background Type="CT_RAW" Source="999C3871" />
+      </Color>
+      <Color Name="FileTabDocumentBorderShadow">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="FileTabDocumentBorderBackground">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="FileTabDocumentBorderHighlight">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="BrandedUITitle">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="BrandedUIBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="BrandedUIText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="BrandedUIBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="BrandedUIFill">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="Light">
+        <Background Type="CT_RAW" Source="001E1E1E" />
+      </Color>
+      <Color Name="Medium">
+        <Background Type="CT_RAW" Source="000D101B" />
+      </Color>
+      <Color Name="Dark">
+        <Background Type="CT_RAW" Source="00103156" />
+      </Color>
+      <Color Name="LightCaption">
+        <Background Type="CT_RAW" Source="00F1F1F1" />
+      </Color>
+      <Color Name="CommandBarCheckBoxMouseOver">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CommandBarToolBarSeparatorHighlight">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="CommandBarOptionsMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarTextHoverOverSelected">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CommandBarCheckBoxDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CommandBarSelectedIconDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarSelectedIconDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TitleBarActiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="TitleBarDragHandle">
+        <Background Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="ToolWindowFloatingFrameInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="99999999" />
+      </Color>
+      <Color Name="RaftedWindowButtonInactiveBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="RaftedWindowButtonInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverInactive">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverInactiveBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowButtonActiveBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="RaftedWindowButtonActiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverActive">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverActiveBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="RaftedWindowButtonHoverActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowButtonDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="RaftedWindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="RaftedWindowButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabProvisionalInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabProvisionalInactiveBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabProvisionalInactiveForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedActive">
+        <Background Type="CT_RAW" Source="FF68217A" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedActiveBorder">
+        <Background Type="CT_RAW" Source="FF68217A" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedActiveForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedInactive">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="FileTabProvisionalSelectedInactiveForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FFE1D3E4" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF4E6685" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverInactive">
+        <Background Type="CT_RAW" Source="FFB064AB" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverInactiveBorder">
+        <Background Type="CT_RAW" Source="FFB064AB" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownInactive">
+        <Background Type="CT_RAW" Source="FF442359" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownInactiveBorder">
+        <Background Type="CT_RAW" Source="FF442359" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedActive">
+        <Background Type="CT_RAW" Source="FF9B4F96" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedActiveBorder">
+        <Background Type="CT_RAW" Source="FF9B4F96" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedActive">
+        <Background Type="CT_RAW" Source="FF442359" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedActiveBorder">
+        <Background Type="CT_RAW" Source="FF442359" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedInactive">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedInactive">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalDownSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="FileTabButtonSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FFD0E6F5" />
+      </Color>
+      <Color Name="FileTabButtonSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF4E6685" />
+      </Color>
+      <Color Name="FileTabButtonHoverInactive">
+        <Background Type="CT_RAW" Source="FFD1F7FF" />
+      </Color>
+      <Color Name="FileTabButtonHoverInactiveBorder">
+        <Background Type="CT_RAW" Source="FFB40066" />
+      </Color>
+      <Color Name="FileTabButtonHoverInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFB40066" />
+      </Color>
+      <Color Name="FileTabButtonDownInactive">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonDownInactiveBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonDownInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedActive">
+        <Background Type="CT_RAW" Source="FFBBB0BB" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedActiveBorder">
+        <Background Type="CT_RAW" Source="FFC3C3C3" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FF272727" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedActive">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedActiveBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedActiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedInactive">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="FileTabButtonHoverSelectedInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabButtonDownSelectedInactive">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="FileTabInactiveBorder">
+        <Background Type="CT_RAW" Source="FF5B0034" />
+      </Color>
+      <Color Name="DropDownMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarSplitButtonSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DropDownButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="DropDownText">
+        <Background Type="CT_RAW" Source="FFC0F3FF" />
+      </Color>
+      <Color Name="DropDownDisabledText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="DropDownMouseOverText">
+        <Background Type="CT_RAW" Source="FFF7007C" />
+      </Color>
+      <Color Name="DropDownMouseDownText">
+        <Background Type="CT_RAW" Source="FFF7007C" />
+      </Color>
+      <Color Name="DropDownButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="DropDownButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DropDownButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxDisabledText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBoxMouseOverText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxMouseDownText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxSelection">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToolWindowTabSelectedActiveText">
+        <Background Type="CT_RAW" Source="FFFF61BA" />
+      </Color>
+      <Color Name="CommandBarTextMouseDown">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarSelectedIconBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarSelectedIcon">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="QuickCustomizeButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="QuickCustomizeButtonBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="QuickCustomizeButtonGlyphHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="QuickCustomizeButtonText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QuickCustomizeButtonTextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QuickCustomizeButtonGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarMouseOverUnfocused">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CommandBarMenuGroupHeaderLinkText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarMenuGroupHeaderLinkTextHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="CommandBarMenuWatermarkLinkTextHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarMenuLinkText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarMenuLinkTextHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="CommandBarMenuWatermarkText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMenuWatermarkLinkText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMenuWatermarkTextHover">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMenuMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Dialog">
+        <Background Type="CT_SYSCOLOR" Source="0000000F" />
+        <Foreground Type="CT_RAW" Source="FFD0D0D0" />
+      </Color>
+      <Color Name="DiagReportLinkText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DiagReportLinkTextHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DocWellOverflowButtonBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="DocWellOverflowButtonGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DocWellOverflowButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ToolWindowTabSeparator">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToolboxDisabledContent">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ToolboxContentMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolboxContent">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToolboxDisabledContentMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="StartPageCheckboxCheckmark">
+        <Background Type="CT_RAW" Source="FFF30506" />
+      </Color>
+      <Color Name="MainWindowInactiveBorder">
+        <Background Type="CT_RAW" Source="FF67003F" />
+      </Color>
+      <Color Name="MainWindowActiveCaption">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="MainWindowInactiveCaption">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="99999999" />
+      </Color>
+      <Color Name="MainWindowButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowButtonInactiveBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="MainWindowButtonInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MainWindowButtonHoverInactive">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="MainWindowButtonHoverInactiveBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="MainWindowButtonHoverInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowButtonActiveBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="MainWindowButtonActiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MainWindowButtonHoverActive">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="MainWindowButtonHoverActiveBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="MainWindowButtonHoverActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowButtonDown">
+        <Background Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="MainWindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="StatusBarDefault">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="MainWindowActiveNoSolutionBorder">
+        <Background Type="CT_RAW" Source="FF5A0071" />
+      </Color>
+      <Color Name="StatusBarBuilding">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="StatusBarDebugging">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFC2FF28" />
+      </Color>
+      <Color Name="StatusBarNoSolution">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF7E2A93" />
+      </Color>
+      <Color Name="MainWindowActiveBuildingBorder">
+        <Background Type="CT_RAW" Source="FF02E49E" />
+      </Color>
+      <Color Name="MainWindowActiveDebuggingBorder">
+        <Background Type="CT_RAW" Source="FFC2FF28" />
+      </Color>
+      <Color Name="MainWindowActiveDefaultBorder">
+        <Background Type="CT_RAW" Source="FFEE0077" />
+      </Color>
+      <Color Name="MainWindowResizeGripTexture2">
+        <Background Type="CT_RAW" Source="7F000000" />
+      </Color>
+      <Color Name="MainWindowResizeGripTexture1">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="VerticalResizeGripEnd">
+        <Background Type="CT_RAW" Source="87FF114F" />
+      </Color>
+      <Color Name="HorizontalResizeGrip">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="VerticalResizeGripBegin">
+        <Background Type="CT_RAW" Source="87FF114F" />
+      </Color>
+      <Color Name="VerticalResizeGripMiddle">
+        <Background Type="CT_RAW" Source="CA64008E" />
+      </Color>
+      <Color Name="TitleBarDragHandleActive">
+        <Background Type="CT_RAW" Source="FFCE0056" />
+      </Color>
+      <Color Name="FileTabButtonProvisionalHoverGlyph">
+        <Background Type="CT_RAW" Source="FFE1D3E4" />
+      </Color>
+      <Color Name="FileTabProvisionalHover">
+        <Background Type="CT_RAW" Source="FF68217A" />
+      </Color>
+      <Color Name="FileTabProvisionalHoverBorder">
+        <Background Type="CT_RAW" Source="FF68217A" />
+      </Color>
+      <Color Name="FileTabProvisionalHoverForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FileTabInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MainWindowInactiveIconNoSolution">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="MainWindowActiveIconDefault">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowActiveIconBuilding">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowActiveIconDebugging">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowActiveIconNoSolution">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MainWindowInactiveIconDefault">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="MainWindowInactiveIconBuilding">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="MainWindowInactiveIconDebugging">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowInactiveIconNoSolution">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowActiveIconDefault">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowActiveIconBuilding">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowActiveIconDebugging">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowActiveIconNoSolution">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowInactiveIconDefault">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowInactiveIconBuilding">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="RaftedWindowInactiveIconDebugging">
+        <Background Type="CT_RAW" Source="66FFFFFF" />
+      </Color>
+      <Color Name="CommandBarMenuItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CommandBarMenuItemMouseOver">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScrollBarArrowGlyphPressed">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="ScrollBarArrowGlyph">
+        <Background Type="CT_RAW" Source="FF9F005A" />
+      </Color>
+      <Color Name="ScrollBarArrowGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ScrollBarArrowGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFFF2790" />
+      </Color>
+      <Color Name="ScrollBarBorder">
+        <Background Type="CT_RAW" Source="A4A40052" />
+      </Color>
+      <Color Name="ScrollBarThumbMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="ScrollBarThumbPressedBorder">
+        <Background Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="ScrollBarThumbGlyphMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="ScrollBarThumbGlyphPressedBorder">
+        <Background Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="StatusBarHighlight">
+        <Background Type="CT_RAW" Source="4C000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScrollBarThumbDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToolTipBorder">
+        <Background Type="CT_RAW" Source="FF41001B" />
+      </Color>
+      <Color Name="ToolTip">
+        <Background Type="CT_RAW" Source="FF001F1E" />
+        <Foreground Type="CT_RAW" Source="FFE8F4FF" />
+      </Color>
+      <Color Name="IconActionFill">
+        <Background Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="IconGeneralFill">
+        <Background Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="IconGeneralStroke">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ToolTipHintText">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="CommandBarMenuScrollGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="PanelHyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="AccessKeyToolTip">
+        <Background Type="CT_RAW" Source="FF999999" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="AccessKeyToolTipBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarSplitButtonGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarSplitButtonMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarSplitButtonMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarMenuGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CommandBarMenuMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CommandBarMenuMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="AutoHideResizeGripDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="AccessKeyToolTipDisabled">
+        <Background Type="CT_RAW" Source="80525252" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="AccessKeyToolTipDisabledBorder">
+        <Background Type="CT_RAW" Source="80525252" />
+      </Color>
+      <Color Name="ComboBoxFocusedButtonSeparator">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxFocusedButtonBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ComboBoxFocusedGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxFocusedBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxFocusedBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxFocusedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxItemMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxItemMouseOverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxItemText">
+        <Background Type="CT_RAW" Source="FFCEF5FF" />
+      </Color>
+      <Color Name="ComboBoxItemTextInactive">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="FileTabBackground">
+        <Background Type="CT_RAW" Source="002B0018" />
+      </Color>
+      <Color Name="ToolWindowTabSelectedBorder">
+        <Background Type="CT_RAW" Source="00003459" />
+      </Color>
+      <Color Name="ToolWindowContentGrid">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelHyperlinkInsideSelection">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PanelHyperlinkInsideSelectionActive">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PanelHyperlinkInsideSelectionInactive">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="EditorAdditionalContentBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PanelDisabledHyperlinkInsideSelectionActive">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="PanelDisabledHyperlinkInsideSelectionInactive">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FF7D7D7D" />
+      </Color>
+      <Color Name="CommandBarMenuSubmenuGlyphHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="VSBrandingText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PreviewTagBackground">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="PreviewTagText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="PreviewTagBackgroundHover">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="PreviewTagTextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PreviewTagBackgroundPressed">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="PreviewTagTextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PreviewTagBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="PreviewTagTextFocused">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PreviewTagBackgroundDisabled">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="PreviewTagTextDisabled">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="ComboBoxFocusBox">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CommandBarFrameControlHover">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="MainWindowSolutionNameActiveBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="MainWindowSolutionNameInactiveBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="MainWindowSolutionNameActiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MainWindowSolutionNameInactiveText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ClassDesignerPrimaryGrabHandle">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ClassDesignerPrimaryLineGrabHandle">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ClassDesignerSecondaryLineGrabHandle">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="FileTabPrimarySeparator">
+        <Background Type="CT_RAW" Source="CE7B03AC" />
+      </Color>
+      <Color Name="FileTabSecondarySeparator">
+        <Background Type="CT_RAW" Source="CE7B03AC" />
+      </Color>
+      <Color Name="FileTabIndicatorTextSelectedActive">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="FileTabIndicatorTextSelectedInactive">
+        <Background Type="CT_RAW" Source="FFA400BD" />
+      </Color>
+      <Color Name="FileTabScrollBarThumb">
+        <Background Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="FileTabScrollBarArrowGlyph">
+        <Background Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="FileTabScrollBarThumbHover">
+        <Background Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="FileTabScrollBarArrowGlyphHover">
+        <Background Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="FileTabScrollBarThumbPressed">
+        <Background Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="FileTabScrollBarArrowGlyphPressed">
+        <Background Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="MainWindowCloudEnvironmentActive">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="MainWindowCloudEnvironmentInactive">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="991E1E1E" />
+      </Color>
+      <Color Name="Halo">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FileTabParentText">
+        <Background Type="CT_RAW" Source="75FFFFFF" />
+      </Color>
+      <Color Name="FileTabGroupTitleBackground">
+        <Background Type="CT_RAW" Source="FF5B0034" />
+      </Color>
+      <Color Name="FileTabActiveGroupTitleBackground">
+        <Background Type="CT_RAW" Source="FFB40066" />
+      </Color>
+      <Color Name="FileTabActiveGroupBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToolWindowValidationErrorBorder">
+        <Background Type="CT_RAW" Source="FFE46364" />
+      </Color>
+      <Color Name="ToolWindowValidationErrorText">
+        <Background Type="CT_RAW" Source="FFE46364" />
+      </Color>
+    </Category>
+    <Category Name="Find" GUID="{4370282e-987e-4ac4-ad14-5ffed2ad1e14}">
+      <Color Name="DropDownMenuMouseDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ErrorBorder">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="AlertBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="UnfocusedDropdown">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+    </Category>
+    <Category Name="Find Results" GUID="{5c48b2cb-0366-4fbf-9786-0bb37e945687}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Current List Location">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="outlining.collapsehintadornment">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="outlining.square">
+        <Background Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFE2E2E2" />
+      </Color>
+      <Color Name="Collapsible Text (Collapsed)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Collapsible Text (Expanded)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="outlining.verticalrule">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Folder Difference" GUID="{b36b0228-dbad-4db0-b9c7-2ad3e572010f}">
+      <Color Name="Different content">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="Identical content">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Source Only">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Target Only">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Not Downloaded">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Even Row Items">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Odd Row Items">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="FSharpInteractive" GUID="{00ccee86-3140-4e06-a65a-a92665a40d6f}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FFA7B7D0" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="GraphDocumentColors" GUID="{0cd5aa2b-ef23-4997-80b5-7d0e8fe5b312}">
+      <Color Name="GraphNodeBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="NoShapeSelectionStartColor">
+        <Background Type="CT_RAW" Source="FFCFE6FD" />
+      </Color>
+      <Color Name="NoShapeSelectionBorder">
+        <Background Type="CT_RAW" Source="FF65A6E7" />
+      </Color>
+      <Color Name="NoShapeSelectionEndColor">
+        <Background Type="CT_RAW" Source="FFCFE6FD" />
+      </Color>
+      <Color Name="GraphGroupBackground">
+        <Background Type="CT_RAW" Source="FFEEEEEE" />
+      </Color>
+      <Color Name="GraphGroupBorder">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="SelectionBrush">
+        <Background Type="CT_RAW" Source="FFFFFF00" />
+      </Color>
+      <Color Name="GlassHighlightStartColor">
+        <Background Type="CT_RAW" Source="3FFFFF00" />
+      </Color>
+      <Color Name="GlassHighlightEndColor">
+        <Background Type="CT_RAW" Source="8FFFFF00" />
+      </Color>
+      <Color Name="GlassBorderStartColor">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="GlassBorderEndColor">
+        <Background Type="CT_RAW" Source="FFD3D3D3" />
+      </Color>
+      <Color Name="InfoBarBackground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="InfoBarForeground">
+        <Background Type="CT_RAW" Source="FFDBF1F2" />
+      </Color>
+      <Color Name="LegendBackgroundColor">
+        <Background Type="CT_RAW" Source="A02D2D30" />
+      </Color>
+      <Color Name="LegendMouseOverBackgroundColor">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="LegendBorderBrush">
+        <Background Type="CT_RAW" Source="A0333337" />
+      </Color>
+      <Color Name="LegendForegroundBrush">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="LinkBrush">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="DiagramPaperFill">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DiagramPaperBorder">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="SelectionBorder">
+        <Background Type="CT_RAW" Source="FFFCD400" />
+      </Color>
+      <Color Name="LinkOutline">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="GraphGroupTitleBar">
+        <Background Type="CT_RAW" Source="FF444444" />
+      </Color>
+      <Color Name="GraphGroupTitleBarText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="LinkNavigatorButtonStrokeStartColor">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="LinkNavigatorButtonStrokeEndColor">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="LinkNavigatorButtonFillStartColor">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="LinkNavigatorButtonFillEndColor">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="LinkNavigatorButtonHoverFillStartColor">
+        <Background Type="CT_RAW" Source="FFC4C4C4" />
+      </Color>
+      <Color Name="LinkNavigatorButtonHoverFillEndColor">
+        <Background Type="CT_RAW" Source="FFC4C4C4" />
+      </Color>
+      <Color Name="LinkNavigatorBubbleFillStartColor">
+        <Background Type="CT_RAW" Source="FFC4C4C4" />
+      </Color>
+      <Color Name="LinkNavigatorBubbleFillEndColor">
+        <Background Type="CT_RAW" Source="FFC4C4C4" />
+      </Color>
+      <Color Name="LinkNavigatorButtonArrowBrush">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ErrorPageHeaderStartColor">
+        <Background Type="CT_RAW" Source="FF496A9F" />
+      </Color>
+      <Color Name="ErrorPageHeaderMiddleColor">
+        <Background Type="CT_RAW" Source="FF476595" />
+      </Color>
+      <Color Name="ErrorPageHeaderEndColor">
+        <Background Type="CT_RAW" Source="FF434E5E" />
+      </Color>
+      <Color Name="ErrorPageMessageBackground">
+        <Background Type="CT_RAW" Source="FFFAFAD2" />
+      </Color>
+      <Color Name="ErrorPageMessageBorder">
+        <Background Type="CT_RAW" Source="FFCCC7BA" />
+      </Color>
+      <Color Name="ExpandoButtonBackground">
+        <Background Type="CT_RAW" Source="80FFFFFF" />
+      </Color>
+      <Color Name="ExpandoButtonChevronBrush">
+        <Background Type="CT_RAW" Source="FF00008B" />
+      </Color>
+      <Color Name="GraphNodeBorder">
+        <Background Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="GraphDragDropFeedback">
+        <Background Type="CT_RAW" Source="FF50FF50" />
+      </Color>
+      <Color Name="GraphGroupContentColor">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="MultiOperationButtonBorder">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="MultiOperationButtonPressedBackground">
+        <Background Type="CT_RAW" Source="90000000" />
+      </Color>
+      <Color Name="MultiOperationButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="20000000" />
+      </Color>
+      <Color Name="ProgressBarColor">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="GraphBackgroundColor">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="GraphTextColor">
+        <Background Type="CT_RAW" Source="FFDBF1F2" />
+      </Color>
+      <Color Name="GraphHyperlinkColor">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="ExpandoButtonBorder">
+        <Background Type="CT_RAW" Source="80FFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="GraphicsDebugger" GUID="{40cdc500-10ac-41df-a533-6af2aaaa0c4b}">
+      <Color Name="KeyLabelText">
+        <Foreground Type="CT_RAW" Source="FFB51631" />
+      </Color>
+    </Category>
+    <Category Name="GraphicsDesigners" GUID="{9cfdb8b3-48aa-4715-ac38-dde2968d204f}">
+      <Color Name="ColorBackgroundGradientStart">
+        <Background Type="CT_RAW" Source="FF1E1E22" />
+      </Color>
+      <Color Name="ColorBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF1E1E22" />
+      </Color>
+      <Color Name="ColorLassoRectangle">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="ColorLassoOutline">
+        <Background Type="CT_SYSCOLOR" Source="0000001A" />
+      </Color>
+      <Color Name="ColorNodeGradientStart">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorNodeGradientEnd">
+        <Background Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="ColorNodeUnselected">
+        <Background Type="CT_RAW" Source="F0202020" />
+      </Color>
+      <Color Name="ColorNodeSelected">
+        <Background Type="CT_RAW" Source="F0FFFF70" />
+      </Color>
+      <Color Name="ColorInputPortBase">
+        <Background Type="CT_RAW" Source="FF05323C" />
+      </Color>
+      <Color Name="ColorInputPortStep">
+        <Background Type="CT_RAW" Source="FF202020" />
+      </Color>
+      <Color Name="ColorOutputPort">
+        <Background Type="CT_RAW" Source="FF707070" />
+      </Color>
+      <Color Name="ColorNodeLabelBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ColorPortTooltipBackground">
+        <Background Type="CT_RAW" Source="C0000000" />
+      </Color>
+      <Color Name="ColorRedChannel">
+        <Background Type="CT_RAW" Source="FF3C0000" />
+      </Color>
+      <Color Name="ColorGreenChannel">
+        <Background Type="CT_RAW" Source="FF003C00" />
+      </Color>
+      <Color Name="ColorBlueChannel">
+        <Background Type="CT_RAW" Source="FF0A0A3C" />
+      </Color>
+      <Color Name="ColorAlphaChannel">
+        <Background Type="CT_RAW" Source="FF3C0F0F" />
+      </Color>
+      <Color Name="ColorLinkNormalHighlight">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorLinkSelectedHighlight">
+        <Background Type="CT_RAW" Source="FFF4FC5A" />
+      </Color>
+      <Color Name="ColorLinkLiveHighlight">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="ColorLinkValidHighlight">
+        <Background Type="CT_RAW" Source="FF00FF00" />
+      </Color>
+      <Color Name="ColorLinkInvalidHighlight">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="ColorDesignerTextDropShadow">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ColorDesignerText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorAlphaChannelBlendVisualization">
+        <Background Type="CT_RAW" Source="FF21B40D" />
+      </Color>
+      <Color Name="ColorSelectionKnobs">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorXAxis">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="ColorYAxis">
+        <Background Type="CT_RAW" Source="FF00FF00" />
+      </Color>
+      <Color Name="ColorZAxis">
+        <Background Type="CT_RAW" Source="FF0000FF" />
+      </Color>
+      <Color Name="ColorManipulatorCenterBlock">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorManipulatorSelectedAxis">
+        <Background Type="CT_RAW" Source="FFFFFF00" />
+      </Color>
+      <Color Name="ColorRotationManipulator">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="ColorSelectedMeshPoint">
+        <Background Type="CT_RAW" Source="FFFFFF00" />
+      </Color>
+      <Color Name="ColorFaceNormals">
+        <Background Type="CT_RAW" Source="FFFF19B4" />
+      </Color>
+      <Color Name="ColorVertexNormals">
+        <Background Type="CT_RAW" Source="FF19B4FF" />
+      </Color>
+      <Color Name="ColorAxisLabelDropShadow">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="ColorGridColor">
+        <Background Type="CT_RAW" Source="FF585858" />
+      </Color>
+      <Color Name="ColorSelectedWireframe">
+        <Background Type="CT_RAW" Source="FF1EFF96" />
+      </Color>
+      <Color Name="ColorAdditionalSelectedWireframe">
+        <Background Type="CT_RAW" Source="FF1E8CFF" />
+      </Color>
+      <Color Name="ColorSceneNodeElement">
+        <Background Type="CT_RAW" Source="FFFF00FF" />
+      </Color>
+      <Color Name="ColorWireframe">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ColorValidDropTarget">
+        <Background Type="CT_RAW" Source="FFF4FC5A" />
+      </Color>
+      <Color Name="ColorSelectedPolygonEdge">
+        <Background Type="CT_RAW" Source="FFFFA700" />
+      </Color>
+      <Color Name="ColorSelectedMeshFace">
+        <Background Type="CT_RAW" Source="FFFFA700" />
+      </Color>
+      <Color Name="ColorMeshPoint">
+        <Background Type="CT_RAW" Source="FFFFA700" />
+      </Color>
+      <Color Name="ColorSelectedMaterial">
+        <Background Type="CT_RAW" Source="FFFFA700" />
+      </Color>
+      <Color Name="ColorSelectedNodeText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="GridCellBorder">
+        <Background Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="InactiveSelectedBackgroundColor">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="InactiveSelectedText">
+        <Background Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="MouseOverBackgroundColor">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="MouseOverText">
+        <Background Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="SelectedBackgroundColor">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="DetailPane">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="FocusDots">
+        <Foreground Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="GridColumnSizer">
+        <Background Type="CT_SYSCOLOR" Source="00000006" />
+      </Color>
+      <Color Name="GridHeaderHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="GridHeaderText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="Menu">
+        <Background Type="CT_SYSCOLOR" Source="00000004" />
+      </Color>
+      <Color Name="MenuBorder">
+        <Background Type="CT_SYSCOLOR" Source="0000000A" />
+      </Color>
+      <Color Name="MenuFocus">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="MenuHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="Progress">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="Splitter">
+        <Background Type="CT_SYSCOLOR" Source="00000006" />
+      </Color>
+      <Color Name="WatermarkText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000011" />
+      </Color>
+      <Color Name="NetworkCacheSelectedText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="NetworkCacheBlurText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="NetworkErrorSelectedText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="NetworkErrorBlurText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="NetworkToolbarButtonTextColor">
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="NetworkToolbarButtonHoverTextColor">
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPopupTextColor">
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPressedTextColor">
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="NetworkGridSecondaryHighlighted">
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="NetworkGridSecondarySelected">
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="NetworkHeaderBackground">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="DropDownButton">
+        <Background Type="CT_SYSCOLOR" Source="0000000F" />
+      </Color>
+      <Color Name="DropDownButtonHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+      </Color>
+      <Color Name="SnapshotButton">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="SnapshotButtonActive">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="SnapshotButtonBorder">
+        <Background Type="CT_SYSCOLOR" Source="0000000B" />
+      </Color>
+      <Color Name="SnapshotButtonBorderActive">
+        <Background Type="CT_SYSCOLOR" Source="0000000A" />
+      </Color>
+      <Color Name="SnapshotButtonBorderHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000A" />
+      </Color>
+      <Color Name="SnapshotButtonDisabled">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="SnapshotButtonDisabledText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000011" />
+      </Color>
+      <Color Name="SnapshotButtonHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+      <Color Name="SnapshotDiffAddedText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="SnapshotDiffModifiedText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="SnapshotMessagesBorder">
+        <Background Type="CT_SYSCOLOR" Source="0000000A" />
+      </Color>
+      <Color Name="SnapshotTile">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="SnapshotTileBaselineText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="SnapshotTileBorder">
+        <Background Type="CT_SYSCOLOR" Source="0000000A" />
+      </Color>
+      <Color Name="SnapshotTileErrorText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="SnapshotTileHeader">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="TabHeader">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+      </Color>
+      <Color Name="TabText">
+        <Foreground Type="CT_SYSCOLOR" Source="00000011" />
+      </Color>
+      <Color Name="TabHover">
+        <Background Type="CT_SYSCOLOR" Source="0000000D" />
+        <Foreground Type="CT_SYSCOLOR" Source="0000000E" />
+      </Color>
+    </Category>
+    <Category Name="Header" GUID="{4997f547-1379-456e-b985-2f413cdfa536}">
+      <Color Name="MouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Default">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="MouseOver">
+        <Background Type="CT_RAW" Source="FF1A053C" />
+        <Foreground Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="MouseDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SeparatorLine">
+        <Background Type="CT_RAW" Source="FF720038" />
+      </Color>
+      <Color Name="Glyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="Immediate Window" GUID="{6bb65c5a-2f31-4bde-9f48-8a38dc0c63e7}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="InfoBar" GUID="{832df9d1-d9a9-4eb7-ad13-ff5b421f7432}">
+      <Color Name="Hyperlink">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkMouseOver">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkMouseDown">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="InfoBarBackground">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CloseButton">
+        <Background Type="CT_RAW" Source="FFFFFFE1" />
+      </Color>
+      <Color Name="CloseButtonGlyph">
+        <Background Type="CT_RAW" Source="FF6A6A6A" />
+      </Color>
+      <Color Name="CloseButtonBorder">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="CloseButtonHover">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="CloseButtonHoverGlyph">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CloseButtonHoverBorder">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="CloseButtonDown">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="CloseButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CloseButtonDownBorder">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="InfoBarBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Button">
+        <Background Type="CT_RAW" Source="FFE2EDFA" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FF707070" />
+      </Color>
+      <Color Name="ButtonMouseOver">
+        <Background Type="CT_RAW" Source="FFE2EDFA" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="ButtonDisabledBorder">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="ButtonMouseDown">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ButtonMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="ButtonFocus">
+        <Background Type="CT_RAW" Source="FFE2EDFA" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonFocusBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="ButtonDisabled">
+        <Background Type="CT_RAW" Source="FFE2EDFA" />
+        <Foreground Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+    </Category>
+    <Category Name="InformationBadge" GUID="{63f9718c-889b-4814-a3b4-6e81d14f1156}">
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Text">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="BackgroundHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BackgroundFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TextFocused">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BackgroundDisabled">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="TextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+    </Category>
+    <Category Name="IntelliTrace" GUID="{ffa74b06-e011-49be-a58c-3efaa4b957d5}">
+      <Color Name="ReportHeaderActive">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DebugHistoryControlPanel">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="ReportAccentBackground">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="VizSurfaceRedDarkHighlight">
+        <Background Type="CT_RAW" Source="FFFF8C8C" />
+      </Color>
+      <Color Name="VizSurfaceRedDarkHover">
+        <Background Type="CT_RAW" Source="FFFF8C8C" />
+      </Color>
+      <Color Name="VizSurfaceRedDarkText">
+        <Background Type="CT_RAW" Source="FFFF8C8C" />
+      </Color>
+      <Color Name="IntelliTraceTimelineBreakpointFill">
+        <Background Type="CT_RAW" Source="FF8F1000" />
+      </Color>
+      <Color Name="IntelliTraceTImelineBreakpointBorder">
+        <Background Type="CT_RAW" Source="FFBF3F00" />
+      </Color>
+      <Color Name="IntelliTraceTimelineStepFill">
+        <Background Type="CT_RAW" Source="FFB18110" />
+      </Color>
+      <Color Name="IntelliTraceTimelineStepBorder">
+        <Background Type="CT_RAW" Source="FFFCB714" />
+      </Color>
+      <Color Name="IntelliTraceTimelineExceptionFill">
+        <Background Type="CT_RAW" Source="FF8F1000" />
+      </Color>
+      <Color Name="IntelliTraceTimelineExceptionBorder">
+        <Background Type="CT_RAW" Source="FFBF3F00" />
+      </Color>
+      <Color Name="IntelliTraceTimelineBreakAllFill">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="IntelliTraceTimelineBreakAllBorder">
+        <Background Type="CT_RAW" Source="FFB5B5B5" />
+      </Color>
+    </Category>
+    <Category Name="InvariantTabbedDesigner" GUID="{cbe82e17-dab9-4324-bb17-c601706ef2ef}">
+      <Color Name="TabActive">
+        <Background Type="CT_SYSCOLOR" Source="0000000F" />
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="TextBoxBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+    </Category>
+    <Category Name="JavaScriptDiagnosticsTools" GUID="{6aacdb12-98d1-4448-affa-ff460b4339e7}">
+      <Color Name="BreadCrumb">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+    </Category>
+    <Category Name="JavaScriptMemory" GUID="{a5441c8f-ed08-40e1-ab04-ba3281d84770}">
+      <Color Name="DropDownButton">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DropDownButtonHover">
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+      </Color>
+      <Color Name="SnapshotButton">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SnapshotButtonActive">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SnapshotButtonBorder">
+        <Background Type="CT_RAW" Source="FFD4D4D4" />
+      </Color>
+      <Color Name="SnapshotButtonBorderActive">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="SnapshotButtonBorderHover">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="SnapshotButtonDisabled">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="SnapshotButtonDisabledText">
+        <Foreground Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="SnapshotButtonHover">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+        <Foreground Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="SnapshotDiffAddedText">
+        <Foreground Type="CT_RAW" Source="FF4E8400" />
+      </Color>
+      <Color Name="SnapshotDiffModifiedText">
+        <Foreground Type="CT_RAW" Source="FF00829C" />
+      </Color>
+      <Color Name="SnapshotMessagesBorder">
+        <Background Type="CT_RAW" Source="FFE5E6ED" />
+      </Color>
+      <Color Name="SnapshotTile">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SnapshotTileBaselineText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="SnapshotTileBorder">
+        <Background Type="CT_RAW" Source="FFD4D4D4" />
+      </Color>
+      <Color Name="SnapshotTileErrorText">
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="SnapshotTileHeader">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="TabHeader">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="TabText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TabHover">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+        <Foreground Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+    </Category>
+    <Category Name="JavaScriptPerformanceTools" GUID="{634eef98-6af2-4f63-8d9f-36351e18b606}">
+      <Color Name="GridCellBorder">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="InactiveSelectedBackgroundColor">
+        <Background Type="CT_RAW" Source="FFD9D9D9" />
+      </Color>
+      <Color Name="InactiveSelectedText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="MouseOverBackgroundColor">
+        <Background Type="CT_RAW" Source="FFE2E2E2" />
+      </Color>
+      <Color Name="MouseOverText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="SelectedBackgroundColor">
+        <Background Type="CT_RAW" Source="FFCCE4F5" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DetailPane">
+        <Background Type="CT_RAW" Source="FFF9F9F9" />
+      </Color>
+      <Color Name="FocusDots">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridColumnSizer">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="GridHeaderHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridHeaderText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Menu">
+        <Background Type="CT_RAW" Source="FFE7E8EC" />
+      </Color>
+      <Color Name="MenuBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="MenuFocus">
+        <Background Type="CT_RAW" Source="D8FFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="MenuHover">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="Progress">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="Splitter">
+        <Background Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="WatermarkText">
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="NetworkCacheSelectedText">
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="NetworkCacheBlurText">
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="NetworkErrorSelectedText">
+        <Foreground Type="CT_RAW" Source="FFE61E27" />
+      </Color>
+      <Color Name="NetworkErrorBlurText">
+        <Foreground Type="CT_RAW" Source="FFE61E27" />
+      </Color>
+      <Color Name="NetworkToolbarButtonTextColor">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="NetworkToolbarButtonHoverTextColor">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPopupTextColor">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="NetworkToolbarButtonPressedTextColor">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="NetworkGridSecondaryHighlighted">
+        <Foreground Type="CT_RAW" Source="FF606060" />
+      </Color>
+      <Color Name="NetworkGridSecondarySelected">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="NetworkHeaderBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+    </Category>
+    <Category Name="JavascriptRequiredForMonacoEditor" GUID="{ca939bd0-e6fd-47f6-8a98-effc40dfab02}">
+      <Color Name="ThemeColor">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="PluginFontEditorColor">
+        <Foreground Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="MonacoGotolineBackgroundColor">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="MonacoGotolineFocusedBackgroundColor">
+        <Background Type="CT_RAW" Source="FFF9C3E0" />
+      </Color>
+      <Color Name="MonacoGotolineHoverBackgroundColor">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="MonacoGotolineSelectedBackgroundColor">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="PluginEditorFocusedSelectedTextBackgroundColor">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="PluginEditorSelectedTextBackgroundColor">
+        <Background Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="PluginFontConsoleErrorColor">
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="PluginFontConsoleInfoColor">
+        <Foreground Type="CT_RAW" Source="FF62001E" />
+      </Color>
+      <Color Name="PluginFontConsoleInputColor">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PluginFontConsoleWarningColor">
+        <Foreground Type="CT_RAW" Source="FF606060" />
+      </Color>
+      <Color Name="PluginFontEditorBreakpointBackgroundColor">
+        <Foreground Type="CT_RAW" Source="FF963A46" />
+      </Color>
+      <Color Name="PluginFontEditorCommentColor">
+        <Foreground Type="CT_RAW" Source="FF62001E" />
+      </Color>
+      <Color Name="PluginFontEditorCssNameColor">
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="PluginFontEditorCssSelectorColor">
+        <Foreground Type="CT_RAW" Source="FF880000" />
+      </Color>
+      <Color Name="PluginFontEditorCssValueColor">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PluginFontEditorErroradornmentBackgroundColor">
+        <Background Type="CT_RAW" Source="FFBA141A" />
+      </Color>
+      <Color Name="PluginFontEditorErroradornmentColor">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PluginFontEditorHtmlAttributeNameColor">
+        <Foreground Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="PluginFontEditorHtmlAttributeValueColor">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PluginFontEditorHtmlElementColor">
+        <Foreground Type="CT_RAW" Source="FFFF6666" />
+      </Color>
+      <Color Name="PluginFontEditorHtmlTagColor">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PluginFontEditorIdentifierColor">
+        <Foreground Type="CT_RAW" Source="FF62001E" />
+      </Color>
+      <Color Name="PluginFontEditorInstructionPointerBackgroundColor">
+        <Background Type="CT_RAW" Source="FFFFEE62" />
+      </Color>
+      <Color Name="PluginFontEditorKeywordColor">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PluginFontEditorLiteralColor">
+        <Foreground Type="CT_RAW" Source="FFE00000" />
+      </Color>
+      <Color Name="PluginFontEditorMarginBackgroundColor">
+        <Background Type="CT_RAW" Source="FFDBE5F5" />
+      </Color>
+      <Color Name="PluginFontEditorMarginColor">
+        <Foreground Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="PluginFontEditorNumberColor">
+        <Foreground Type="CT_RAW" Source="FFA31515" />
+      </Color>
+      <Color Name="PluginFontEditorSearchResultBackgroundColor">
+        <Background Type="CT_RAW" Source="FFF6B94D" />
+      </Color>
+      <Color Name="PluginFontEditorStringColor">
+        <Foreground Type="CT_RAW" Source="FFA31515" />
+      </Color>
+      <Color Name="PluginHighlightBorderColor">
+        <Foreground Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="PluginTabHeaderHoverBackgroundColor">
+        <Background Type="CT_RAW" Source="FFEEEEEE" />
+      </Color>
+      <Color Name="PluginWordHighlightColor">
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="PluginWordHighlightStrongColor">
+        <Foreground Type="CT_RAW" Source="B3F9CE82" />
+      </Color>
+      <Color Name="VsDropShadowBackgroundColor">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+    </Category>
+    <Category Name="JavaScriptResponsiveness" GUID="{6adcf200-0249-47f3-b14f-ab041a443e9b}">
+      <Color Name="GraphBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DropDownButtonHover">
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+      </Color>
+    </Category>
+    <Category Name="ListViewGrid" GUID="{63dec435-18e1-4e62-a9a9-0495fcb524a3}">
+      <Color Name="Border">
+        <Background Type="CT_RAW" Source="FF6F88A4" />
+      </Color>
+      <Color Name="GridLines">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="SelectedCellBorder">
+        <Background Type="CT_RAW" Source="FFA0A0A0" />
+      </Color>
+    </Category>
+    <Category Name="Locals" GUID="{8259aced-490a-41b3-a0fb-64c842ccdc80}">
+      <Color Name="ChangedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF7A1A1" />
+      </Color>
+      <Color Name="Plain Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Logcat" GUID="{1d30081b-8d57-4391-bba5-4168aa50ba6d}">
+      <Color Name="EntryIWDCategory">
+        <Foreground Type="CT_RAW" Source="FF404040" />
+      </Color>
+      <Color Name="EntryECategory">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EntryVCategory">
+        <Foreground Type="CT_RAW" Source="FFC3C3C3" />
+      </Color>
+      <Color Name="Pid">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+    </Category>
+    <Category Name="ManifestDesigner" GUID="{b239f458-9f75-4376-959b-4d48b89337f4}">
+      <Color Name="TabActive">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabInactive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DescriptionPane">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Watermark">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+    </Category>
+    <Category Name="NavigateTo" GUID="{d58e4793-9fe6-450b-b200-b93a3c17aa12}">
+      <Color Name="ResultListItem">
+        <Background Type="CT_RAW" Source="FF7E0032" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ResultListItemDescriptionText">
+        <Background Type="CT_RAW" Source="AAFFFFFF" />
+      </Color>
+      <Color Name="ResultListBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ResultListAccentBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ResultList">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ResultListDescriptionText">
+        <Background Type="CT_RAW" Source="AAF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="NewProjectDialog" GUID="{c36c426e-31c9-4048-84cf-31c111d65ec0}">
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="Wonderbar">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WonderbarTreeInactiveSelected">
+        <Background Type="CT_RAW" Source="9EA40064" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WonderbarTreeSelected">
+        <Background Type="CT_RAW" Source="FFA40064" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Details">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Content">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ContentMouseOver">
+        <Background Type="CT_RAW" Source="84A40064" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ContentSelected">
+        <Background Type="CT_RAW" Source="FFA40064" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ContentSelectedBorder">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="ContentInactiveSelected">
+        <Background Type="CT_RAW" Source="84A40064" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WonderbarMouseOver">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WonderbarSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TreeArrowChecked">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TreeArrow">
+        <Background Type="CT_RAW" Source="000D101B" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TreeArrowMouseOver">
+        <Background Type="CT_RAW" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ImageBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="PageButtonBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="TextBoxSelection">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TextBoxBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TextBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TextBoxDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TextBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TextBoxFocused">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BackgroundLowerRegion">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InputFocusBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TextBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CheckBoxMouseOver">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBox">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="WatermarkText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="WizardBackgroundLowerRegion">
+        <Background Type="CT_RAW" Source="FF252526" />
+      </Color>
+    </Category>
+    <Category Name="NotificationBubble" GUID="{800c5171-6625-4a74-b3e2-a6cd0b4698d4}">
+      <Color Name="NotificationBubbleBorder">
+        <Background Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="NotificationBubbleBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NotificationBubbleForeground">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBubbleHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="NotificationBubbleCloseButtonGlyph">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBubbleCloseButtonHoverGlyph">
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="NotificationBubbleCloseButtonPressedGlyph">
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonHoverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonHoverGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButton">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="NotificationBubbleWindowButtonGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBubbleWindowPanel">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="Output Window" GUID="{9973efdf-317d-431c-8bc1-5e88cbfd4f7f}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Current List Location">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="urlformat">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="OutputHeading">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="OutputError">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="OutputVerbose">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Package Manager Console" GUID="{f9d6bce6-c669-41db-8ee7-dd953828685b}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FFA7B7D0" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Text in High Contrast">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="PackageManifestEditor" GUID="{3f27d653-86e6-4a04-adb6-a35efa6c8f05}">
+      <Color Name="SelectedCategoryTab">
+        <Background Type="CT_RAW" Source="FFDD007D" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CategoryTab">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC80071" />
+      </Color>
+      <Color Name="MouseOverCategoryTab">
+        <Background Type="CT_RAW" Source="FFC4FDFF" />
+        <Foreground Type="CT_RAW" Source="FF424242" />
+      </Color>
+      <Color Name="TextBoxSelection">
+        <Background Type="CT_RAW" Source="FF393E66" />
+      </Color>
+      <Color Name="TextBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC80071" />
+      </Color>
+      <Color Name="TextBoxBorder">
+        <Background Type="CT_RAW" Source="FF74FFFD" />
+      </Color>
+      <Color Name="TextBoxDisabled">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+        <Foreground Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="TextBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="TextBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFB1B9C9" />
+      </Color>
+      <Color Name="InputFocusBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="EditorContent">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC80071" />
+      </Color>
+      <Color Name="CheckBoxMouseOver">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC80071" />
+      </Color>
+      <Color Name="CheckBox">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC80071" />
+      </Color>
+    </Category>
+    <Category Name="Page Inspector" GUID="{6cbc7204-91b7-416b-a1a1-34b94142998e}">
+      <Color Name="SelectionFeedback">
+        <Background Type="CT_RAW" Source="281382CE" />
+        <Foreground Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="StaticInspectionBorder">
+        <Foreground Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="DynamicInspectionBorder">
+        <Foreground Type="CT_RAW" Source="FFFF8027" />
+      </Color>
+    </Category>
+    <Category Name="Parallel Stacks" GUID="{4330ebb5-2f04-4e03-8414-69f6035087e0}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Parallel Tasks" GUID="{53371a83-c565-4995-817a-166fff2df0d3}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Parallel Watch" GUID="{e02a3ccd-2d8e-4628-97d7-1c0921dfa2f3}">
+      <Color Name="Plain Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="ChangedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="Performance Tips" GUID="{7a4c6cc9-8404-4b95-af88-f11b657c7268}">
+      <Color Name="Selected Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+    </Category>
+    <Category Name="ProgressBar" GUID="{94acf70f-a81d-4512-a31d-8196616751ee}">
+      <Color Name="IndicatorFill">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="IndicatorFillWarning">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="IndicatorFillCritical">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+    </Category>
+    <Category Name="ProjectDesigner" GUID="{ef1a2d2c-5d16-4ddb-8d04-79d0f6c1c56e}">
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SelectedCategoryTab">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CategoryTab">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MouseOverCategoryTab">
+        <Background Type="CT_RAW" Source="FF25456D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="Promotion" GUID="{8fafb063-4106-4756-81dc-d7769f24d056}">
+      <Color Name="LightboxBackgroundOverlay">
+        <Background Type="CT_RAW" Source="70D9D9D9" />
+      </Color>
+      <Color Name="LightboxDialogBackgroundPanel">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="LightboxDialogPanelBodyText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="LightboxDialogPanelBorder">
+        <Background Type="CT_RAW" Source="FF7B7B7B" />
+      </Color>
+      <Color Name="LightboxDialogButton">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LightboxDialogButtonBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="LightboxDialogButtonPressed">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LightboxDialogButtonBorderPressed">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="LightboxDialogButtonHover">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LightboxDialogButtonBorderHover">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="LightboxDialogButtonFocused">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LightboxDialogButtonBorderFocused">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="LightboxDialogButtonDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="LightboxDialogButtonBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="LightboxDialogHeadline">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="LightboxDialogHeading">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="LightboxDialogCloseButtonGlyph">
+        <Foreground Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="LightboxDialogCloseButtonGlyphHover">
+        <Foreground Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="LightboxDialogCloseButtonGlyphFocused">
+        <Foreground Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+    </Category>
+    <Category Name="SearchControl" GUID="{f1095fad-881f-45f1-8580-589e10325eb8}">
+      <Color Name="Selection">
+        <Background Type="CT_RAW" Source="FF92007D" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MouseOverBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MouseOverBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="MouseOverWatermarkText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DisabledBorder">
+        <Background Type="CT_RAW" Source="7E103156" />
+      </Color>
+      <Color Name="DisabledDownButtonGlyph">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ActionButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ActionButtonMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActionButtonMouseDown">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="StopGlyph">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="SearchGlyph">
+        <Background Type="CT_RAW" Source="FF169AFF" />
+      </Color>
+      <Color Name="ClearGlyph">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="ActionButtonDisabledGlyph">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="Unfocused">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="UnfocusedWatermarkText">
+        <Background Type="CT_RAW" Source="00B6005B" />
+      </Color>
+      <Color Name="UnfocusedBorder">
+        <Background Type="CT_RAW" Source="009F005A" />
+      </Color>
+      <Color Name="Disabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="MouseDownDropDownButtonGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="MouseOverDropDownButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="MouseOverDropDownButtonGlyph">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="MouseDownDropDownButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="UnfocusedDropDownButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="UnfocusedDropDownButtonGlyph">
+        <Background Type="CT_RAW" Source="FF169AFF" />
+      </Color>
+      <Color Name="PopupControlMouseDownBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="PopupBorder">
+        <Background Type="CT_RAW" Source="7652FFFF" />
+      </Color>
+      <Color Name="PopupItemsListBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupItemsListBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupSectionBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupSectionHeaderSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="PopupSectionHeaderText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="PopupSectionHeaderGradientBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupSectionHeaderGradientEnd">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupButtonText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseOverText">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseDownText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PopupCheckboxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupCheckboxMouseOverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupCheckboxMouseDownText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupItemText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupMouseOverItemText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PopupControlMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupControlMouseDownBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="PopupControlMouseOverBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupControlMouseOverBackgroundGradientMiddle1">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupControlMouseOverBackgroundGradientMiddle2">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupControlMouseOverBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupControlMouseDownBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="PopupControlMouseDownBackgroundGradientMiddle1">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="PopupControlMouseDownBackgroundGradientMiddle2">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="PopupSectionBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="PopupButtonMouseDownBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseDownBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseDownBackgroundGradientMiddle1">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupButtonMouseDownBackgroundGradientMiddle2">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="MouseOverDropDownButtonBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="UnfocusedDropDownButtonBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="MouseDownDropDownButtonBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="ActionButtonMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="ActionButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="SearchActiveBackground">
+        <Background Type="CT_RAW" Source="7E103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ActionButtonMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="PopupCheckboxCheckmark">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DropDownSeparator">
+        <Background Type="CT_RAW" Source="00103156" />
+      </Color>
+      <Color Name="MouseOverDropDownSeparator">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="FocusedDropDownButton">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="FocusedDropDownButtonBorder">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="FocusedDropDownButtonGlyph">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="FocusedDropDownSeparator">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="FocusedBorder">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+      <Color Name="FocusedBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MouseOverStopGlyph">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="MouseOverSearchGlyph">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="MouseOverClearGlyph">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="FocusedStopGlyph">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="FocusedSearchGlyph">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="FocusedClearGlyph">
+        <Background Type="CT_RAW" Source="FFA40064" />
+      </Color>
+    </Category>
+    <Category Name="SharePointTools" GUID="{7e8da76d-24b4-447c-8ece-ff8e0e73f0d4}">
+      <Color Name="DesignerWindow">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DesignerSelectedTab">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DesignerDefaultTab">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DesignerMouseOverTab">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="SQL Results - Grid" GUID="{6202ff3e-488e-4ead-92cb-be089659f8d7}">
+      <Color Name="Header Row">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Selected Cell">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Cell">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Null Value Cell">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Grid Cell">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="SQL Results - Text" GUID="{587d0421-e473-4032-b214-9359f3b7bc80}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="StartPage" GUID="{65d78f35-869e-4bf3-8e52-991fee554a16}">
+      <Color Name="StartPageBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="StartPageBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageHeadingText">
+        <Foreground Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="StartPageListItem">
+        <Background Type="CT_SYSCOLOR" Source="00000005" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageListItemPressed">
+        <Background Type="CT_RAW" Source="FF82004F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageSupportText">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartPageSupportTextHover">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartPageSupportTextPressed">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartPageListItemGlyphHover">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="StartPageListItemGlyphPressed">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageNewsBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageTimeStamp">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartPageListItemHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageListItemGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="MRUSecondaryForeground">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="VideoRSSItem">
+        <Background Type="CT_RAW" Source="FF2D2D2D" />
+      </Color>
+      <Color Name="VideoRSSItemHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="VideoRSSItemPressed">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="VideoRSSItemTitle">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="VideoRSSItemTitleMouseOver">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="VideoRSSItemTitlePressed">
+        <Foreground Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="VideoRSSItemDuration">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="VideoRSSItemDurationMouseOver">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="VideoRSSItemDurationPressed">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="DisabledProjectCommand">
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="DiscoverTitleText">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="UserConsent">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ItemHeadingText">
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageCheckBoxText">
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="StartPageCheckBoxMouseOverText">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxPressedText">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxBackground">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="StartPageCheckBoxMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageCheckBoxPressedBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxBorder">
+        <Foreground Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="StartPageCheckBoxMouseOverBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxPressedBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxCheckMark">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageCheckBoxMouseOverCheckMark">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageCheckBoxPressedCheckMark">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPagePartitionLine">
+        <Background Type="CT_RAW" Source="FF333333" />
+      </Color>
+      <Color Name="StartPageButton">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageButtonBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF656565" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="StartPageButtonMouseOverBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageButtonMouseDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageButtonMouseDownBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="StartPageDefaultBannerBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageLeftPanelBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="StartPageNewText">
+        <Background Type="CT_RAW" Source="FFFF8C00" />
+        <Foreground Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="StartPageNotificationDotBorder">
+        <Foreground Type="CT_RAW" Source="FF25456D" />
+      </Color>
+      <Color Name="StartPageNotificationDot">
+        <Foreground Type="CT_RAW" Source="FFFFBA00" />
+      </Color>
+      <Color Name="DefaultBannerLink">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DefaultBannerLinkHover">
+        <Foreground Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="DefaultBannerLinkPressed">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="VisualStudioLogoText">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AzureInvitationBannerTitle">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageTitleText">
+        <Foreground Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="StartPageExpander">
+        <Background Type="CT_RAW" Source="FF25456D" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageExpanderHover">
+        <Background Type="CT_RAW" Source="FF606060" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageExpanderPressed">
+        <Background Type="CT_RAW" Source="FF25456D" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartPageCloseButtonGlyph">
+        <Foreground Type="CT_RAW" Source="FFEFEBEF" />
+      </Color>
+      <Color Name="StartPageCloseButtonHoverGlyph">
+        <Foreground Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="StartPageCloseButtonDownGlyph">
+        <Foreground Type="CT_RAW" Source="FF9E9E9E" />
+      </Color>
+      <Color Name="StartPageBackgroundOpacity">
+        <Background Type="CT_RAW" Source="33000000" />
+      </Color>
+    </Category>
+    <Category Name="TabbedDesigner" GUID="{35e33be4-027b-40b5-83a3-c10540994010}">
+      <Color Name="DescriptionPane">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="TabActive">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="TabInactive">
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="TabMouseOver">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="Watermark">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="TextBoxBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="TextBoxBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="TextBoxDisabled">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+        <Foreground Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="TextBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="TextBoxFocused">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="TextBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="TextBoxSelection">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ButtonBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF555555" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="CheckboxBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CheckboxMouseOver">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CheckboxUnselectedItemBackgroundBegin">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CheckboxUnselectedItemBackgroundEnd">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CheckboxUnselectedItemStroke">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="CheckboxTextMouseOver">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="CheckboxBorder">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ButtonDisabledBorder">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="ButtonPressed">
+        <Background Type="CT_RAW" Source="FFDCDCE4" />
+        <Foreground Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="ButtonPressedBorder">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="ButtonIsDefaultBorder">
+        <Background Type="CT_RAW" Source="FF1D52B2" />
+      </Color>
+      <Color Name="ButtonDisabled">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+        <Foreground Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="ListItemForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ListItemDisabledForeground">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="ListItemMouseOver">
+        <Background Type="CT_RAW" Source="FFF2F7FD" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ListItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFB8D6FB" />
+      </Color>
+      <Color Name="ListItemSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ComboBoxBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+      </Color>
+      <Color Name="ComboBoxButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxDisabledBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="ComboBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="ComboBoxDisabledGlyph">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="ComboBoxDisabledText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="ComboBoxGlyph">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ComboBoxMouseDownBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxMouseDownText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxMouseOverText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ComboBoxPopupBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="ComboBoxSelection">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="ComboBoxText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CommandBarTextActive">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CommandBarTextHover">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="CommandBarTextInactive">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="DropDownBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DropDownButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DropDownButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFC9DEF5" />
+      </Color>
+      <Color Name="DropDownButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DropDownDisabledBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="DropDownDisabledBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DropDownDisabledGlyph">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DropDownDisabledText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="DropDownGlyph">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="DropDownMouseDownBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DropDownMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownMouseDownText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DropDownMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DropDownMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DropDownMouseOverText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DropDownPopupBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DropDownText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DropShadowBackground">
+        <Background Type="CT_RAW" Source="72000000" />
+      </Color>
+      <Color Name="ComboBoxMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxPopupBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownPopupBackground">
+        <Background Type="CT_RAW" Source="FFE7E8EC" />
+      </Color>
+      <Color Name="ListItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ListBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemSelectedInactive">
+        <Background Type="CT_RAW" Source="FFF2F2F2" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ListItemSelectedInactiveBorder">
+        <Background Type="CT_RAW" Source="FFDADADA" />
+      </Color>
+      <Color Name="TreeViewLine">
+        <Background Type="CT_RAW" Source="FFE3E3E3" />
+      </Color>
+      <Color Name="TreeViewHighlight">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="SectionControlHeaderBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="SectionControlBackground">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="TreeViewBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TabDisabled">
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="TabHeaderFocused">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+    </Category>
+    <Category Name="Task Runner Explorer" GUID="{af57483a-a3e2-4330-a7cd-21f3dc681594}">
+      <Color Name="PlainText">
+        <Background Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="InactiveSelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+    </Category>
+    <Category Name="TaskRunnerExplorerControls" GUID="{abb9394c-8c5a-447e-b1b7-965e0b6abbc3}">
+      <Color Name="FocusVisual">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Button">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="ButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ButtonHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ButtonDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ButtonBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ButtonFocused">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxTextHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxTextPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CheckBoxTextFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBackgroundHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CheckBoxBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CheckBoxBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CheckBoxBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CheckBoxBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CheckBoxGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphPressed">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CheckBoxGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="CheckBoxGlyphFocused">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ComboBoxSeparator">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxGlyph">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBoxSeparatorDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxGlyphDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ComboBoxBackgroundPressed">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxSeparatorPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxBackgroundHover">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="ComboBoxBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxSeparatorHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ComboBoxBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxBorderFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxTextFocused">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxSeparatorFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphFocused">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxGlyphBackgroundFocused">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxListItemBackgroundHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxListItemBorderHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxListItemTextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxListItemText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ComboBoxListBackground">
+        <Background Type="CT_RAW" Source="FF1F1F1C" />
+      </Color>
+      <Color Name="ComboBoxListBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ComboBoxSelection">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ComboBoxListBackgroundShadow">
+        <Background Type="CT_RAW" Source="19000000" />
+      </Color>
+      <Color Name="ComboBoxTextInputSelection">
+        <Background Type="CT_RAW" Source="66B6005B" />
+      </Color>
+      <Color Name="SecondaryTabBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SecondaryTabBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SecondaryTabText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabHoverBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabHoverBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphHoverBackground">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphHoverBorder">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphPressedBackground">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="SecondaryTabHoverGlyphPressedBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="SecondaryTabPressedBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabPressedBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabPressedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabPressedGlyphPressed">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondarySelectedTabBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="SecondarySelectedTabBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SecondarySelectedTabText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphHoverBackground">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphHoverBorder">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphPressedBackground">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="SecondarySelectedTabGlyphPressedBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="SecondaryTabFocusedBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabFocusedBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SecondaryTabFocusedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphHoverBackground">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphHoverBorder">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphPressedBackground">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="SecondaryTabFocusedGlyphPressedBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="CustomTabText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CustomTabHoverBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CustomTabHoverBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CustomTabHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CustomTabPressedBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CustomTabPressedBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="CustomTabPressedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CustomSelectedTabBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="CustomSelectedTabBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CustomSelectedTabText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="TeamExplorer" GUID="{4aff231b-f28a-44f0-a66b-1beeb17cb920}">
+      <Color Name="ActionLinkItem">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkItemSelected">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActionLinkItemSelectedNotFocused">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkItemHover">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionLinkItemDisabled">
+        <Foreground Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="Subdued">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TextBox">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TextBoxBorder">
+        <Background Type="CT_RAW" Source="FF3F5D7D" />
+      </Color>
+      <Color Name="RequiredTextBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CodeReviewDiscussionItemSelected">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CodeReviewDiscussionSelectedActionLink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TextBoxHintText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="ButtonDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF3F5D7D" />
+      </Color>
+      <Color Name="ButtonMouseOver">
+        <Background Type="CT_RAW" Source="FF3E424F" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF6D6D6D" />
+      </Color>
+      <Color Name="ButtonBorder">
+        <Background Type="CT_RAW" Source="FF3E424F" />
+      </Color>
+      <Color Name="Button">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ButtonPressedBorder">
+        <Background Type="CT_RAW" Source="FFC8347E" />
+      </Color>
+      <Color Name="CallToActionButton">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CallToActionButtonBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="CallToActionButtonDisabled">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF6D6D6D" />
+      </Color>
+      <Color Name="CallToActionButtonDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="CallToActionButtonMouseOver">
+        <Background Type="CT_RAW" Source="FFDB68A2" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CallToActionButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="CallToActionButtonPressed">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CallToActionButtonPressedBorder">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="InnerTabHeader">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabActive">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabInactive">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="InnerTabPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CodeReviewDiscussionDisabledActionLink">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TeamExplorerHomeDefaultIconFill">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TeamExplorerHomeWITFamilyIconFill">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TeamExplorerHomeSCCFamilyIconFill">
+        <Background Type="CT_RAW" Source="FF68217A" />
+      </Color>
+      <Color Name="TeamExplorerHomeBuildFamilyIconFill">
+        <Background Type="CT_RAW" Source="FF6E7582" />
+      </Color>
+      <Color Name="TeamExplorerHomeSCCGitFamilyIconFill">
+        <Background Type="CT_RAW" Source="FFF05033" />
+      </Color>
+      <Color Name="TeamExplorerHomeDocumentsFamilyIconFill">
+        <Background Type="CT_RAW" Source="FFF9C900" />
+      </Color>
+      <Color Name="TeamExplorerHomeReportsFamilyIconFill">
+        <Background Type="CT_RAW" Source="FFAE3CBA" />
+      </Color>
+      <Color Name="TETileIconBackground">
+        <Background Type="CT_RAW" Source="FF3D3D3D" />
+      </Color>
+      <Color Name="TETileListBackground">
+        <Background Type="CT_RAW" Source="FF2D2D2D" />
+      </Color>
+      <Color Name="TETileListForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TETileIconBackgroundMouseOver">
+        <Background Type="CT_RAW" Source="FF525252" />
+      </Color>
+      <Color Name="TETileListBackgroundMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TETileListForegroundMouseOver">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TETileIconBackgroundSelected">
+        <Background Type="CT_RAW" Source="FFA85182" />
+      </Color>
+      <Color Name="TETileListBackgroundSelected">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="TETileListForegroundSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="VSLogoIconFill">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="VSTSLogoIconFill">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EmbeddedDialog">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+    </Category>
+    <Category Name="Text Editor Language Service Items" GUID="{e0187991-b458-4f7e-8ca9-42c9a573b56c}">
+      <Color Name="Keyword">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB151FF" />
+      </Color>
+      <Color Name="Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF0071DB" />
+      </Color>
+      <Color Name="Identifier">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFB007E" />
+      </Color>
+      <Color Name="String">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF0EF3FF" />
+      </Color>
+      <Color Name="Number">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFD400" />
+      </Color>
+      <Color Name="XML CData Section">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="XML Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF80FF80" />
+      </Color>
+      <Color Name="Memory Changed">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="Memory Address">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9B9B9B" />
+      </Color>
+      <Color Name="Memory Unreadable">
+        <Background Type="CT_RAW" Source="FFEDE0D1" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Register Data Changed">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="Register NAT">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF8F8F8F" />
+      </Color>
+      <Color Name="XAML Text">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFABABAB" />
+      </Color>
+      <Color Name="XAML Keyword">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="XAML Delimiter">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="XAML Comment">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="XAML Name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE6E6E6" />
+      </Color>
+      <Color Name="XAML Attribute">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF8CF1EF" />
+      </Color>
+      <Color Name="XAML CData Section">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC0D088" />
+      </Color>
+      <Color Name="XAML Processing Instruction">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFBBA08C" />
+      </Color>
+      <Color Name="XAML Attribute Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="XAML Attribute Quotes">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="XAML Markup Extension Class">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFBBA08C" />
+      </Color>
+      <Color Name="XAML Markup Extension Parameter Name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="XAML Markup Extension Parameter Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB1B1B1" />
+      </Color>
+      <Color Name="XML Text">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDFFDFF" />
+      </Color>
+      <Color Name="XML Keyword">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="XML Delimiter">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFDD2D83" />
+      </Color>
+      <Color Name="XML Name">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF0DEBFF" />
+      </Color>
+      <Color Name="XML Attribute">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF464FF" />
+      </Color>
+      <Color Name="XML Processing Instruction">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF76FBBE" />
+      </Color>
+      <Color Name="XML Attribute Value">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFE7FF6C" />
+      </Color>
+      <Color Name="XML Attribute Quotes">
+        <Background Type="CT_AUTOMATIC" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="XSLT Keyword">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="Memory Data">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Register Data">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF96363" />
+      </Color>
+      <Color Name="SQL Stored Procedure">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SQL System Table">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SQL System Function">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SQL Operator">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF818181" />
+      </Color>
+      <Color Name="SQL String">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SQLCMD Command">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="Error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+    </Category>
+    <Category Name="Text Editor Text Manager Items" GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Selected Text">
+        <Background Type="CT_RAW" Source="FF87739B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Inactive Selected Text">
+        <Background Type="CT_RAW" Source="FF737A9B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Indicator Margin">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Visible Whitespace">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF144852" />
+      </Color>
+    </Category>
+    <Category Name="Text Editor Text Marker Items" GUID="{ff349800-ea43-46c1-8c98-878e78f46501}">
+      <Color Name="Read-Only Region">
+        <Background Type="CT_RAW" Source="FF5A5A5A" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Task List Shortcut">
+        <Background Type="CT_RAW" Source="FF8CF1EF" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Bookmark">
+        <Background Type="CT_RAW" Source="FF7E6551" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="compiler error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF5FCAC8" />
+      </Color>
+      <Color Name="syntax error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF59FF01" />
+      </Color>
+      <Color Name="hinted suggestion">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFA5A5A5" />
+      </Color>
+      <Color Name="other error">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFCA79EC" />
+      </Color>
+      <Color Name="Current List Location">
+        <Background Type="CT_RAW" Source="FF7200CF" />
+        <Foreground Type="CT_RAW" Source="FFFF0676" />
+      </Color>
+      <Color Name="compiler warning">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="Code Snippet Field">
+        <Background Type="CT_RAW" Source="FF5B5B5B" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Code Snippet Field (Selected)">
+        <Background Type="CT_RAW" Source="FF462100" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Smart Tag">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="Track Changes before save">
+        <Background Type="CT_RAW" Source="FFEFF284" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Track Changes after save">
+        <Background Type="CT_RAW" Source="FF577430" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Brace Matching (Rectangle)">
+        <Background Type="CT_RAW" Source="FF757575" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Definition Window Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Definition Window Current Match">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="Warning Lines Path">
+        <Background Type="CT_RAW" Source="FFB5CEA8" />
+        <Foreground Type="CT_RAW" Source="FF051B40" />
+      </Color>
+      <Color Name="Refactoring Background">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Code Snippet Dependent Field">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFB6613D" />
+      </Color>
+      <Color Name="Refactoring Current Field">
+        <Background Type="CT_RAW" Source="FF507470" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Refactoring Dependent Field">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF9B9B9B" />
+      </Color>
+      <Color Name="Tracepoint - Mapped (Enabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="Tracepoint (Disabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFEA7E85" />
+      </Color>
+      <Color Name="Tracepoint - Mapped (Error)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFEA7E85" />
+      </Color>
+      <Color Name="Breakpoint - Advanced (Enabled)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Tracepoint (Error)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="Tracepoint - Mapped (Warning)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="Tracepoint - Advanced (Disabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="Tracepoint - Advanced (Warning)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="Tracepoint - Mapped (Disabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+      <Color Name="Tracepoint (Enabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFD7BA7D" />
+      </Color>
+      <Color Name="Breakpoint - Advanced (Warning)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Breakpoint - Mapped (Warning)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Breakpoint - Mapped (Error)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Breakpoint - Advanced (Error)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Current Statement">
+        <Background Type="CT_RAW" Source="FFEFF284" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Executing Thread IP">
+        <Background Type="CT_RAW" Source="FFD7BA7C" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Current Statement (new context)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFEA7E5F" />
+      </Color>
+      <Color Name="Breakpoint (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFAEAEAE" />
+      </Color>
+      <Color Name="Breakpoint (Error)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Tracepoint - Advanced (Error)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFEA7E5F" />
+      </Color>
+      <Color Name="Breakpoint (Warning)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Coverage Touched Area">
+        <Background Type="CT_RAW" Source="FF5FCAC8" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Coverage Not Touched Area">
+        <Background Type="CT_RAW" Source="FFEDE0D1" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Breakpoint - Selected">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF888888" />
+      </Color>
+      <Color Name="Coverage Partially Touched Area">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Breakpoint (Enabled)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Call Return">
+        <Background Type="CT_RAW" Source="FF7CA5A0" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Call Return (historical mode)">
+        <Background Type="CT_RAW" Source="FFD69D85" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Current Statement (historical mode)">
+        <Background Type="CT_RAW" Source="FFB5CEA8" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="Tracepoint - Advanced (Enabled)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFEFF284" />
+      </Color>
+      <Color Name="Breakpoint - Mapped (Enabled)">
+        <Background Type="CT_RAW" Source="FF8C2F2F" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Tracepoint (Warning)">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="Collapsible Text (Collapsed)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="Collapsible Text (Expanded)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="Bookmark (Disabled)">
+        <Background Type="CT_RAW" Source="FFB1F9F8" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Brace Matching (Highlight)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint - Advanced (Enabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Alert)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint - Advanced (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Alert)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Breakpoint - Advanced (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="Snappoint (Error)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Checked)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint - Advanced (Error)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Logpoint - Advanced (Warning)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Breakpoint - Mapped (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="Logpoint (Dashed)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint - Advanced (Alert)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint (Warning)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Enabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint (Alert)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint (Enabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Error)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Enabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Warning)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SQL DML Marker">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FF00D2CB" />
+      </Color>
+      <Color Name="Executing Threads IPs">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Checked)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Warning)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint - Advanced (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Call Return (new context)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Snappoint (Dashed)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint (Disabled)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="Logpoint (Error)">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFFFDBA3" />
+      </Color>
+      <Color Name="Error Message">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFD85050" />
+      </Color>
+    </Category>
+    <Category Name="ThemedDialog" GUID="{5e04b2a9-e443-48db-8791-63a2a71cfbd7}">
+      <Color Name="WindowPanel">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowBorder">
+        <Background Type="CT_RAW" Source="6E37001B" />
+      </Color>
+      <Color Name="HeaderText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="HyperlinkPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="SelectedItemActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SelectedItemInactive">
+        <Background Type="CT_RAW" Source="FF75003B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListItemMouseOver">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemDisabledText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="GridHeadingBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingHoverBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridHeadingHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridLine">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="WizardFooter">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="SectionDivider">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="WindowButton">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="WindowButtonHover">
+        <Background Type="CT_RAW" Source="FF323232" />
+      </Color>
+      <Color Name="WindowButtonDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WindowButtonBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="WindowButtonHoverBorder">
+        <Background Type="CT_RAW" Source="FF323232" />
+      </Color>
+      <Color Name="WindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WindowButtonGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowButtonHoverGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ListBox">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListBoxBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ListBoxDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ListBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="TagText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagBorder">
+        <Background Type="CT_RAW" Source="FF323232" />
+      </Color>
+      <Color Name="TagBackground">
+        <Background Type="CT_RAW" Source="FF323232" />
+      </Color>
+      <Color Name="PromotionBoxBackground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="PromotionBoxBorder">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="PromotionBoxText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ValidationError">
+        <Background Type="CT_RAW" Source="FFE46364" />
+      </Color>
+      <Color Name="ValidationErrorText">
+        <Background Type="CT_RAW" Source="FFE46364" />
+      </Color>
+      <Color Name="ActionButtonBackground">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+       <Color Name="ActionButtonBackgroundActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ActionButtonStroke">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ActionButtonStrokeHover">
+        <Background Type="CT_RAW" Source="FF52FFFF" />
+      </Color>
+      <Color Name="ActionButtonStrokeActive">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActionButtonText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActionButtonTextActive">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="StartWindowDescription">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartWindowDescriptionActive">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="StartWindowDescriptionHover">
+        <Foreground Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="CloseWindowButtonHover">
+        <Background Type="CT_RAW" Source="FFE81123" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TemplateNewTag">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TemplateNewTagSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+    </Category>
+    <Category Name="ThemedUtilityDialog" GUID="{e2961a72-48a5-4da7-8168-1fee490f78a7}">
+      <Color Name="ActiveCaption">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="WindowBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="WindowPanel">
+        <Background Type="CT_RAW" Source="FF252526" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowButton">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="WindowButtonHover">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="WindowButtonDown">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="WindowButtonBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="WindowButtonHoverBorder">
+        <Background Type="CT_RAW" Source="72555555" />
+      </Color>
+      <Color Name="WindowButtonDownBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="WindowButtonGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowButtonDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WindowButtonHoverGlyph">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+    </Category>
+    <Category Name="Threads" GUID="{bb8fe807-a186-404a-81fa-d20b908ca93b}">
+      <Color Name="Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="TreeView" GUID="{92ecf08e-8b13-4cf4-99e9-ae2692382185}">
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFBDFCFF" />
+      </Color>
+      <Color Name="SelectedItemActive">
+        <Background Type="CT_RAW" Source="FFA40064" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SelectedItemInactive">
+        <Background Type="CT_RAW" Source="FF5E003A" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="FocusVisualBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HighlightedSpan">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="SelectedItemActiveGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="Glyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="SelectedItemActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DragOverItem">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DragOverItemGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DragOverItemGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SelectedItemInactiveGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="SelectedItemInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DragDropInsertionArrowBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ValidationSquiggles">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="DragDropInsertionArrow">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+    </Category>
+    <Category Name="UnthemedDialog" GUID="{d1fae935-144d-45a6-af9a-d615e3cd7b75}">
+      <Color Name="Hyperlink">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkPressed">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+    </Category>
+    <Category Name="UserInformation" GUID="{b6d9f1fc-e422-4755-a014-3fb666d831dc}">
+      <Color Name="IDCardText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="IDCardBackground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="IDCardBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="IDCardSeparator">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ErrorText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="ErrorBackground">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+      <Color Name="ErrorHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="IDCardInactiveText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="IDCardMinimalModeText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="IDCardMinimalModeInactiveWindowText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="IDCardMinimalModeInactiveText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="IDCardMinimalModeInactiveWindowInactiveText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+    </Category>
+    <Category Name="UserNotifications" GUID="{5d42b198-efca-431c-92aa-8b595d0d39c2}">
+      <Color Name="SeverityCritical">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="SeverityImportant">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="SeverityInformative">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="SeverityVSUpdate">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="SubtitleText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="SubtitleMouseOverText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TitleText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TitleMouseOverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="NotificationMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="Content">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationBorder">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="NotificationMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="NotificationGlyph">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationGlyphMouseOver">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="NotificationGlyphMouseDown">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="NotificationGlyphMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="NotificationGlyphMouseDownBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalActive">
+        <Background Type="CT_RAW" Source="FFF22930" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalActiveBorder">
+        <Background Type="CT_RAW" Source="FFF22930" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCountActive">
+        <Background Type="CT_RAW" Source="FF8631C7" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCountInactive">
+        <Background Type="CT_RAW" Source="FF8631C7" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCountMouseDown">
+        <Background Type="CT_RAW" Source="FF8631C7" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCountMouseOverActive">
+        <Background Type="CT_RAW" Source="FF8631C7" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCountMouseOverInactive">
+        <Background Type="CT_RAW" Source="FF8631C7" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCriticalActive">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="BadgeButtonCriticalActiveBorder">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="BadgeButtonCriticalActiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalInactive">
+        <Background Type="CT_RAW" Source="FFF22930" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalInactiveBorder">
+        <Background Type="CT_RAW" Source="FFF22930" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverCriticalInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonCriticalInactive">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="BadgeButtonCriticalInactiveBorder">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="BadgeButtonCriticalInactiveGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownCritical">
+        <Background Type="CT_RAW" Source="FFD20F17" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownCriticalBorder">
+        <Background Type="CT_RAW" Source="FFD20F17" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownCriticalGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateActive">
+        <Background Type="CT_RAW" Source="FFFFDF66" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateActiveBorder">
+        <Background Type="CT_RAW" Source="FFFFDF66" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateActiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateActive">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateActiveBorder">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateActiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateInactive">
+        <Background Type="CT_RAW" Source="FFFFDF66" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateInactiveBorder">
+        <Background Type="CT_RAW" Source="FFFFDF66" />
+      </Color>
+      <Color Name="BadgeButtonMouseOverVSUpdateInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateInactive">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateInactiveBorder">
+        <Background Type="CT_RAW" Source="FFFFCC00" />
+      </Color>
+      <Color Name="BadgeButtonVSUpdateInactiveGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownVSUpdate">
+        <Background Type="CT_RAW" Source="FFC59E00" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownVSUpdateBorder">
+        <Background Type="CT_RAW" Source="FFC59E00" />
+      </Color>
+      <Color Name="BadgeButtonMouseDownVSUpdateGlyph">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="NotificationSelectedBackground">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="NotificationSelectedBorder">
+        <Background Type="CT_RAW" Source="FF04071F" />
+      </Color>
+      <Color Name="TitleSelectedText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="SubtitleSelectedText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="IgnoredBackground">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="IgnoredBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="IgnoredMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF525252" />
+      </Color>
+      <Color Name="IgnoredMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF525252" />
+      </Color>
+      <Color Name="IgnoredSelectedBackground">
+        <Background Type="CT_RAW" Source="FFDBE5F5" />
+      </Color>
+      <Color Name="IgnoredSelectedBorder">
+        <Background Type="CT_RAW" Source="FFDBE5F5" />
+      </Color>
+      <Color Name="IgnoredTitleText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="IgnoredSubtitleText">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="IgnoredTitleSelectedText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="IgnoredSubtitleSelectedText">
+        <Background Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="IgnoredTitleMouseOverText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="IgnoredSubtitleMouseOverText">
+        <Background Type="CT_RAW" Source="FF9FA7B6" />
+      </Color>
+      <Color Name="IgnoredHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="IgnoredSelectedHyperlink">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="IgnoredMouseOverHyperlink">
+        <Background Type="CT_RAW" Source="FFED9CC5" />
+      </Color>
+      <Color Name="ToastPanelBackground">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ToastTitleText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToastMessageText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToastPanelBorder">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastGlyphButton">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToastGlyphButtonHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastGlyphButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastActionButton">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToastActionButtonBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToastActionButtonText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToastActionButtonHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToastActionButtonBorderHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastActionButtonTextHover">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ToastActionButtonPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastActionButtonBorderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="ToastActionButtonDisabled">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+      </Color>
+      <Color Name="ToastActionButtonBorderDisabled">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ToastActionButtonTextDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="ToastActionButtonTextPressed">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="IndicatorBubble">
+        <Background Type="CT_RAW" Source="FFE41400" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="IndicatorBubbleDebugging">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="UnreadText">
+        <Background Type="CT_RAW" Source="FFE86222" />
+      </Color>
+      <Color Name="UnreadMouseOverText">
+        <Background Type="CT_RAW" Source="FFE86222" />
+      </Color>
+      <Color Name="CreationText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="CreationMouseOverText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ExpirationText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ExpirationMouseOverText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="DescriptionText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DescriptionMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DescriptionSelectedText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="UnreadSelectedText">
+        <Background Type="CT_RAW" Source="FFE86222" />
+      </Color>
+      <Color Name="CreationSelectedText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ExpirationSelectedText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+    </Category>
+    <Category Name="VersionControl" GUID="{6be84f44-74e4-4e5f-aee9-1b930f431375}">
+      <Color Name="FolderDiffRed">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="AnnotateRegion">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="AnnotateRegionSelected">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="VisualProfiler" GUID="{cf3994af-130f-4f0d-a84e-3601e4e357d9}">
+      <Color Name="HintText">
+        <Background Type="CT_RAW" Source="FF7C7C7C" />
+      </Color>
+    </Category>
+    <Category Name="VisualStudioInstaller" GUID="{53212856-7528-403d-84e6-76820f4cef73}">
+      <Color Name="Background">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="Border">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="HeaderTextBrand">
+        <Background Type="CT_RAW" Source="FF865FC5" />
+      </Color>
+      <Color Name="PivotText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="PivotBar">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="SectionDivider">
+        <Background Type="CT_RAW" Source="FF9EB4CB" />
+      </Color>
+      <Color Name="HeaderText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="SectionHeaderText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="SupportText">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="BodyText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="HyperlinkPressed">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+    </Category>
+    <Category Name="VsGraphics" GUID="{1b5630dd-453f-45e0-94f0-7413c05fff83}">
+      <Color Name="AddressText">
+        <Background Type="CT_RAW" Source="FF707070" />
+      </Color>
+      <Color Name="SelectedAddressText">
+        <Background Type="CT_RAW" Source="7FFFFFFF" />
+      </Color>
+      <Color Name="SelectedInactiveAddressText">
+        <Background Type="CT_RAW" Source="7F1E1E1E" />
+      </Color>
+      <Color Name="RedHighlightText">
+        <Foreground Type="CT_RAW" Source="FFCA1729" />
+      </Color>
+      <Color Name="LayoverBackground">
+        <Background Type="CT_RAW" Source="50787878" />
+      </Color>
+      <Color Name="LayoverRibbon">
+        <Background Type="CT_RAW" Source="FFF1F1DC" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="VsyncLineColor">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="StateSetUnchanged">
+        <Foreground Type="CT_RAW" Source="FF825F1E" />
+      </Color>
+      <Color Name="StateSetChanged">
+        <Foreground Type="CT_RAW" Source="FFF7A1A1" />
+      </Color>
+      <Color Name="GridHeaderLine">
+        <Foreground Type="CT_RAW" Source="FFE0E3E6" />
+      </Color>
+      <Color Name="KeyboardFocus">
+        <Foreground Type="CT_RAW" Source="FF898989" />
+      </Color>
+      <Color Name="KeyboardFocusSelected">
+        <Foreground Type="CT_RAW" Source="FF404040" />
+      </Color>
+    </Category>
+    <Category Name="VSSearch" GUID="{04ba5a31-6d4d-4225-9194-2e38a9175e31}">
+      <Color Name="TabSelectionActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WindowPanelText">
+        <Background Type="CT_SYSCOLOR" Source="00000008" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WindowPanelTabDivider">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="WindowPanelSupportText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="WindowPanelBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="WindowPanel">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="ListItemBackgroundHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ListItemBorderHover">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="ListItemSupportTextHover">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="Watch" GUID="{358463d0-d084-400f-997e-a34fc570bc72}">
+      <Color Name="ChangedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_RAW" Source="FFF7A1A1" />
+      </Color>
+      <Color Name="Plain Text">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <Color Name="SelectedText">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="WebClient Diagnostic Tools" GUID="{2aa714ae-53be-4393-84e0-dc95b57a1891}">
+      <Color Name="Plain Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Console Input Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFCB76A3" />
+      </Color>
+      <Color Name="Console Output Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Console Info Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF3AFD3" />
+      </Color>
+      <Color Name="Console Error Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFFF6666" />
+      </Color>
+      <Color Name="Console Warning Text">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFFEFCC8" />
+      </Color>
+    </Category>
+    <Category Name="WelcomeExperience" GUID="{df76799d-28de-4975-81af-3357270f57eb}">
+      <Color Name="WelcomeExperienceButtonMousedownBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonMouseoverForeground">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonMousedownForeground">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonMousedownBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonMouseoverBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonBorder">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonBackground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonMouseoverBackground">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="WelcomeExperienceButtonForeground">
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMousedownBackground">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMouseoverForeground">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMousedownForeground">
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMousedownBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMouseoverBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonBackground">
+        <Background Type="CT_RAW" Source="FFE2EDFA" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonMouseoverBackground">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="WelcomeExperienceDistinctButtonForeground">
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="WelcomeExperienceBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="WelcomeExperienceForeground">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+    </Category>
+    <Category Name="WindowsTemplateStudio" GUID="{9c63f223-700a-4418-8a5a-cd450f05f593}">
+      <Color Name="WindowPanel">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="WindowBorder">
+        <Background Type="CT_RAW" Source="FF3F3F46" />
+      </Color>
+      <Color Name="HeaderText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Hyperlink">
+        <Background Type="CT_RAW" Source="FF5C6BC0" />
+      </Color>
+      <Color Name="HyperlinkHover">
+        <Background Type="CT_RAW" Source="FF3F51B5" />
+      </Color>
+      <Color Name="HyperlinkDisabled">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="SelectedItemActive">
+        <Background Type="CT_RAW" Source="FF3F51B5" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SelectedItemInactive">
+        <Background Type="CT_RAW" Source="FF3F3F46" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemMouseOver">
+        <Background Type="CT_RAW" Source="FF3F3F40" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ListItemDisabledText">
+        <Background Type="CT_RAW" Source="FF656565" />
+      </Color>
+      <Color Name="GridHeadingBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingHoverBackground">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="GridHeadingText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridHeadingHoverText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridLine">
+        <Background Type="CT_RAW" Source="FF3F3F46" />
+      </Color>
+      <Color Name="WizardFooter">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="SectionDivider">
+        <Background Type="CT_RAW" Source="FF3F3F46" />
+      </Color>
+      <Color Name="HeaderTextSecondary">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="WizardFooterText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="CardTitleText">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="CardDescriptionText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CardBackgroundDefault">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardBackgroundHover">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="CardBackgroundSelected">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="CardBackgroundDisabled">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="CardBorderDefault">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="CardBorderHover">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="CardBorderSelected">
+        <Background Type="CT_RAW" Source="FF3F51B5" />
+      </Color>
+      <Color Name="CardBorderDisabled">
+        <Background Type="CT_RAW" Source="FF3F3F46" />
+      </Color>
+      <Color Name="DeleteTemplateIcon">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="SavedTemplateBackgroundHover">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+      </Color>
+      <Color Name="NewItemFileStatusNewFile">
+        <Background Type="CT_RAW" Source="FF00CC6A" />
+      </Color>
+      <Color Name="NewItemFileStatusModifiedFile">
+        <Background Type="CT_RAW" Source="FF7986CB" />
+      </Color>
+      <Color Name="NewItemFileStatusConflictingFile">
+        <Background Type="CT_RAW" Source="FFE51400" />
+      </Color>
+      <Color Name="NewItemFileStatusConflictingStylesFile">
+        <Background Type="CT_RAW" Source="FFFFB900" />
+      </Color>
+      <Color Name="NewItemFileStatusWarningFile">
+        <Background Type="CT_RAW" Source="FFFFB900" />
+      </Color>
+      <Color Name="NewItemFileStatusUnchangedFile">
+        <Background Type="CT_RAW" Source="FF3F51B5" />
+      </Color>
+      <Color Name="CardIcon">
+        <Background Type="CT_RAW" Source="FF727779" />
+      </Color>
+      <Color Name="CardFooterText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TemplateInfoPageDescription">
+        <Background Type="CT_RAW" Source="FF727779" />
+      </Color>
+      <Color Name="ChangesSummaryDetailFileHeader">
+        <Background Type="CT_RAW" Source="FF2D2D30" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+    </Category>
+    <Category Name="WorkflowDesigner" GUID="{e0f1945b-b965-47dc-b22e-3e26a895c895}">
+      <Color Name="WorkflowViewElementSelectedBorder">
+        <Background Type="CT_RAW" Source="FF7ABAFA" />
+      </Color>
+      <Color Name="AnnotationBackgroundGradientBegin">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="AnnotationBackgroundGradientMiddle">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="AnnotationBorder">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="AnnotationDockButton">
+        <Background Type="CT_RAW" Source="FF424242" />
+      </Color>
+      <Color Name="AnnotationDockButtonHoverBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AnnotationDockButtonHoverBorder">
+        <Background Type="CT_RAW" Source="FF7ABAFA" />
+      </Color>
+      <Color Name="AnnotationDockButtonHover">
+        <Background Type="CT_RAW" Source="FF424242" />
+      </Color>
+      <Color Name="AnnotationDockText">
+        <Background Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="AnnotationUndockText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="DesignerViewBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DesignerViewShellBarCaptionActive">
+        <Background Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="DesignerViewShellBarCaption">
+        <Background Type="CT_RAW" Source="FF525354" />
+      </Color>
+      <Color Name="DesignerViewShellBarColorGradientBegin">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="DesignerViewShellBarColorGradientEnd">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="DesignerViewShellBarControlBackground">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="DesignerViewShellBarHoverColorGradientBegin">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DesignerViewShellBarHoverColorGradientEnd">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DesignerViewShellBarSelectedColorGradientBegin">
+        <Background Type="CT_RAW" Source="FFC6E1FD" />
+      </Color>
+      <Color Name="DesignerViewShellBarSelectedColorGradientEnd">
+        <Background Type="CT_RAW" Source="FFC6E1FD" />
+      </Color>
+      <Color Name="DesignerViewStatusBarBackground">
+        <Background Type="CT_RAW" Source="FFBDBDBE" />
+      </Color>
+      <Color Name="GridViewRowHover">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="TreeViewBackground">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="TreeViewCollapsedArrowBorder">
+        <Background Type="CT_RAW" Source="FF989898" />
+      </Color>
+      <Color Name="TreeViewCollapsedArrowHoverBorder">
+        <Background Type="CT_RAW" Source="FF1BBBFA" />
+      </Color>
+      <Color Name="TreeViewExpandedArrowBorder">
+        <Background Type="CT_RAW" Source="FF262626" />
+      </Color>
+      <Color Name="TreeViewExpandedArrow">
+        <Background Type="CT_RAW" Source="FF595959" />
+      </Color>
+      <Color Name="TreeViewItemHighlightBackground">
+        <Background Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="TreeViewItemSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TreeViewItemText">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="WorkflowViewElementBackground">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="WorkflowViewElementBorder">
+        <Background Type="CT_RAW" Source="FFD7D7E2" />
+      </Color>
+      <Color Name="WorkflowViewElementCaption">
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="WorkflowViewElementSelectedBackground">
+        <Background Type="CT_RAW" Source="FFC6E1FD" />
+      </Color>
+      <Color Name="AnnotationBackgroundGradientEnd">
+        <Background Type="CT_RAW" Source="FFF0F0F0" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarTextBoxBorder">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PropertyInspectorSelectedForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PropertyInspectorSelectedBackground">
+        <Background Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF1382CE" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarItemSelectedBackground">
+        <Background Type="CT_RAW" Source="FFD0D2D3" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarSeparator">
+        <Background Type="CT_RAW" Source="FFD0D2D3" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarItemHoverBackground">
+        <Background Type="CT_RAW" Source="FFE8E9E9" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarItemHoverBorder">
+        <Background Type="CT_RAW" Source="FFE8E9E9" />
+      </Color>
+      <Color Name="PropertyInspectorToolBarBackground">
+        <Background Type="CT_RAW" Source="FFD0D2D3" />
+      </Color>
+      <Color Name="PropertyInspectorText">
+        <Background Type="CT_RAW" Source="FF525354" />
+      </Color>
+      <Color Name="PropertyInspectorBackground">
+        <Background Type="CT_RAW" Source="FFE6E7E8" />
+      </Color>
+      <Color Name="PropertyInspectorPane">
+        <Background Type="CT_RAW" Source="FFD0D2D3" />
+      </Color>
+      <Color Name="PropertyInspectorCategoryCaptionText">
+        <Background Type="CT_RAW" Source="FF525354" />
+      </Color>
+      <Color Name="PropertyInspectorBorder">
+        <Background Type="CT_RAW" Source="FFD0D2D3" />
+      </Color>
+    </Category>
+    <Category Name="WorkItemEditor" GUID="{2138d120-456d-425e-80b5-88d2401fca23}">
+      <Color Name="ActiveControl">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ActiveControlBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="DefaultControl">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DefaultControlBorder">
+        <Background Type="CT_RAW" Source="FF3F5D7D" />
+      </Color>
+      <Color Name="InvalidControl">
+        <Background Type="CT_RAW" Source="FFFEFCC8" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="InvalidControlBorder">
+        <Background Type="CT_RAW" Source="FF3F5D7D" />
+      </Color>
+      <Color Name="ReadOnlyControl">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="ReadOnlyControlBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="ErrorControl">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="ErrorControlBorder">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="Form">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Label">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="GroupBox">
+        <Background Type="CT_RAW" Source="FF333333" />
+        <Foreground Type="CT_RAW" Source="FFA6A6A6" />
+      </Color>
+      <Color Name="TabItem">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="TabHeader">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="TabHeaderActive">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TabHeaderHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="DropDownHover">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="DropDownPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DropDownInactive">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="GridSortedCell">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="Grid">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="GridBorder">
+        <Background Type="CT_RAW" Source="FF103156" />
+      </Color>
+      <Color Name="GridRowHeader">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridColumnHeader">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+        <Foreground Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="GridActiveRowHeader">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GridActiveColumnHeader">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GridCell">
+        <Background Type="CT_RAW" Source="FF000B1E" />
+        <Foreground Type="CT_RAW" Source="FFC3CCDD" />
+      </Color>
+      <Color Name="GridActiveCell">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GridInactiveCell">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="HtmlControl">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="HtmlControlHyperlink">
+        <Background Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="ButtonSelectedOverride">
+        <Background Type="CT_RAW" Source="FF090C1D" />
+      </Color>
+      <Color Name="GridColumnHeaderPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="GridColumnHeaderHover">
+        <Background Type="CT_RAW" Source="FF103156" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="HtmlControlSecondaryText">
+        <Background Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="PromptText">
+        <Background Type="CT_RAW" Source="FF999999" />
+      </Color>
+      <Color Name="Tag">
+        <Background Type="CT_RAW" Source="FF424242" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagHover">
+        <Background Type="CT_RAW" Source="FF606060" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagActive">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagHoverGlyphHover">
+        <Background Type="CT_RAW" Source="FF393939" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagHoverGlyphPressed">
+        <Background Type="CT_RAW" Source="FFB6005B" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagActiveGlyphHover">
+        <Background Type="CT_RAW" Source="FFDB68A2" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagActiveGlyphPressed">
+        <Background Type="CT_RAW" Source="FF862B60" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TagActiveGlyphHoverBorder">
+        <Foreground Type="CT_RAW" Source="FFDB68A2" />
+      </Color>
+      <Color Name="TagActiveGlyphPressedBorder">
+        <Foreground Type="CT_RAW" Source="FF862B60" />
+      </Color>
+      <Color Name="TagHoverGlyphHoverBorder">
+        <Foreground Type="CT_RAW" Source="FF393939" />
+      </Color>
+      <Color Name="TagHoverGlyphPressedBorder">
+        <Foreground Type="CT_RAW" Source="FFB6005B" />
+      </Color>
+      <Color Name="TagButtonBorder">
+        <Foreground Type="CT_RAW" Source="FF424242" />
+      </Color>
+    </Category>
+    <Category Name="XamarinDesigner" GUID="{78d640b7-154a-4d1e-bbe8-fee14b3ccf29}">
+      <Color Name="DeviceBorder">
+        <Background Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="DesignerSurfaceBackground">
+        <Background Type="CT_SYSCOLOR" Source="0000000F" />
+      </Color>
+      <Color Name="DialogErrorText">
+        <Background Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="EditorColorSwatchBorder">
+        <Background Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+    </Category>
+    <Category Name="XAML Designer" GUID="{fa937f7b-c0d2-46b8-9f10-a7a92642b384}">
+      <Color Name="Artboard Background">
+        <Background Type="CT_INVALID" Source="00000000" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+    </Category>
+    <Category Name="LightSwitch" GUID="{caac64dc-1d25-4244-b1db-8c3a3e8e21c8}">
+      <Color Name="DesignTimeComboBoxDisabledBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="StringEditorDisabledForeground">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="StringEditorDisabledBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="StringEditorSolidBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="StringEditorSelectedSolidBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="StringEditorSquiggle">
+        <Background Type="CT_RAW" Source="FFF20A0A" />
+      </Color>
+      <Color Name="DataGridBorder">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DataGridElementBackground1">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DataGridElementBackground2">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="DataGridElementDisabledBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DataGridRowTitle">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="DataGridBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DataGridRowBorder">
+        <Background Type="CT_RAW" Source="00000000" />
+      </Color>
+      <Color Name="DataGridRowHeaderDark">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DataGridRowHeaderLight">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="DataGridSelectRowBorder">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="AddRelationshipDialogUMLDiagramBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AddRelationshipDialogLineColor">
+        <Background Type="CT_RAW" Source="FFA9A9A9" />
+      </Color>
+      <Color Name="AddRelationshipDialogDarkBackground">
+        <Background Type="CT_RAW" Source="FFD3D3D3" />
+      </Color>
+      <Color Name="AddRelationshipDialogControlBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EntityDesignerPrimaryEntityTitleForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EntityDesignerFieldListTitleBackground">
+        <Background Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityUnselectedHeaderBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityUnselectedHeaderForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityUnselectedLine">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntitySelectedHeaderBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntitySelectedHeaderForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntitySelectedLine">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxSelectedForeground">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxDisabledForeground">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxSelectedBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxDisabledBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxBackground">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxDisabledBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewSelectedForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewDisabledForeground">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewSelectedBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewDisabledBackground">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageCategoryBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="PropertyPageBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="DesignerWelcomeUILinkForeground">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="DesignerWelcomeUILinkForegroundNoHover">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityMousedOverHeaderBackground">
+        <Background Type="CT_RAW" Source="FF1C97EA" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityMousedOverHeaderForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityMousedOverLine">
+        <Background Type="CT_RAW" Source="FF1C97EA" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntityBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenActiveSelectionBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenActiveSelectionForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenInactiveSelectionBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="ScreenInactiveSelectionForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScreenInactiveSelectionBorder">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="ScreenNavigationLinkTextForeground">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="AddNewScreenDialogBackground">
+        <Background Type="CT_SYSCOLOR" Source="0000000F" />
+      </Color>
+      <Color Name="AddNewScreenDialogLightBackground">
+        <Background Type="CT_SYSCOLOR" Source="00000016" />
+      </Color>
+      <Color Name="ScreenDesignerBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="ScreenHeaderTitleForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScreenStripeLineBrush">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ScreenChildMemberStripeLineBrush">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="ScreenMemberNodeBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="ScreenLeftArrowBrush">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ScreenRightArrowBrush">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ScreenChildMemberBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenNodeForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="QueryDesignerListItemText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenNodeContainerForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="ScreenHintText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="ScreenTreeViewLines">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="ScreenContentItemSeparator">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="QueryDesignerTextLiteral">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="QueryDesignerTextParameter">
+        <Background Type="CT_RAW" Source="FF339933" />
+      </Color>
+      <Color Name="QueryDesignerTextProperty">
+        <Background Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="QueryDesignerTextGlobal">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="QueryDesignerDisabledText">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="QueryDesignerFilterConditionGroupBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerListItemBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerHeaderTitleForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonHoverForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonDisabledForeground">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="QueryDesignerLabelRunModeForeground">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="QueryDesignerSummarizedHeaderForeground">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxForeground">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="EntityDesignerBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntitySelectedMousedOverHeaderBackground">
+        <Background Type="CT_RAW" Source="FF1C97EA" />
+      </Color>
+      <Color Name="PropertyPageCategoryText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenControlTypePressedBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenContentItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenContentItemSelectedBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenContentItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenContentItemMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenControlTypeMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenControlTypeMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenControlTypePopupBackground">
+        <Background Type="CT_RAW" Source="FF001419" />
+      </Color>
+      <Color Name="ScreenControlTypePopupBorder">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="ScreenControlTypePopupIconChannel">
+        <Background Type="CT_RAW" Source="FF001419" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF20454F" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemSelectedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemSelectedBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenControlTypePopupItemText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenControlTypePressedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="EntityDesignerRelatedEntitySelectedMousedOverHeaderForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenChildMemberSelectedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenMemberNodeText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenMemberNodeSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenMemberNodeSelectedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenChildMemberText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenChildMemberSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonPressedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonDisabledText">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonPressedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonPressedBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonPressedGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="QueryDesignerAddButtonText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="QueryDesignerListItemBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerNormalGroupBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="ScreenRelationshipEndBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="QueryDesignerTreeViewSelectedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenQueryDesignerNavigationLinkActiveText">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="ScreenQueryDesignerNavigationText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ScreenQueryDesignerNavigationLinkText">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="DataGridRowMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF20454F" />
+      </Color>
+      <Color Name="DataGridRowMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DataGridRowSelectedBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DataGridRowSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DataGridRowText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="PropertyPageText">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="DesignerDropDownButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DesignerDropDownBackground">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="DesignerDropDownBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="DesignerDropDownDisabledBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DesignerDropDownDisabledBorder">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="DesignerDropDownDisabledGlyph">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="DesignerDropDownGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DesignerDropDownMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DesignerDropDownMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DesignerDropDownMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="DesignerDropDownMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="DesignerDropDownMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DesignerDropDownPopupBackground">
+        <Background Type="CT_RAW" Source="FF001419" />
+      </Color>
+      <Color Name="DesignerDropDownPopupBorder">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="DesignerDropDownMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DesignerDropDownButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="DesignerDropDownText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DesignerDropDownDisabledText">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="DesignerDropDownMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DesignerDropDownMouseDownText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="DesignerDropDownButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DesignerDropDownButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="QueryDesignerTextBoxSelectedBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="WriteCodeButtonLinkTextMouseOver">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="WriteCodeButtonCategoryText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="WriteCodeButtonCategoryBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="WriteCodeButtonLinkText">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="PropertyPageCategoryMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenSplitterBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="AddNewScreenDialogHeaderText">
+        <Background Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="AddNewScreenDialogText">
+        <Background Type="CT_SYSCOLOR" Source="00000012" />
+      </Color>
+      <Color Name="DataGridRowDisabledText">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="ScreenQueryDesignerNavigationBackground">
+        <Background Type="CT_RAW" Source="FF565656" />
+      </Color>
+      <Color Name="ScreenControlTypePressedGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ScreenControlTypeMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="ScreenControlTypeGlyph">
+        <Background Type="CT_RAW" Source="FF44646A" />
+      </Color>
+      <Color Name="PropertyPageDropDownText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="PropertyPageDropDownBackground">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="PropertyPageDropDownBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageDropDownButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="PropertyPageDropDownButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="PropertyPageDropDownButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="PropertyPageDropDownButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="PropertyPageDropDownDisabledBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="PropertyPageDropDownDisabledBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageDropDownDisabledGlyph">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageDropDownDisabledText">
+        <Background Type="CT_RAW" Source="FF3A555A" />
+      </Color>
+      <Color Name="PropertyPageDropDownGlyph">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseDownText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseOverBackground">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF477786" />
+      </Color>
+      <Color Name="PropertyPageDropDownMouseOverText">
+        <Background Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="PropertyPageDropDownPopupBackground">
+        <Background Type="CT_RAW" Source="FF001419" />
+      </Color>
+      <Color Name="PropertyPageDropDownPopupBorder">
+        <Background Type="CT_RAW" Source="FF003542" />
+      </Color>
+      <Color Name="EntityDesignerPrimaryEntityTitleSelection">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DesignerLinkText">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="DesignerTextSelection">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="PropertyPageDropDownTextSelection">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="DesignerDropDownTextSelection">
+        <Background Type="CT_RAW" Source="FF0097FB" />
+      </Color>
+      <Color Name="DesignerWelcomeUILinkForegroundHover">
+        <Background Type="CT_RAW" Source="FF55AAFF" />
+      </Color>
+      <Color Name="DesignerWelcomeUIBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="DesignerWelcomeUIForeground">
+        <Background Type="CT_RAW" Source="FFF1F1F1" />
+      </Color>
+      <Color Name="DesignerWelcomeUIGroupBackground">
+        <Background Type="CT_RAW" Source="FF001E26" />
+      </Color>
+      <Color Name="DesignerWelcomeUISeparator">
+        <Background Type="CT_RAW" Source="FF003C49" />
+      </Color>
+      <Color Name="QueryDesignerBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenContentItemBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="ScreenDesignerMembersBackground">
+        <Background Type="CT_RAW" Source="FF002B36" />
+      </Color>
+      <Color Name="DataGridRowMouseOverBorder">
+        <Background Type="CT_RAW" Source="FF2D535B" />
+      </Color>
+      <Color Name="AppDesignerErrorForeground">
+        <Background Type="CT_RAW" Source="FFFF0000" />
+      </Color>
+      <Color Name="SharedFieldsDataGridHeaderBackground">
+        <Background Type="CT_RAW" Source="FFEEEEF2" />
+      </Color>
+      <Color Name="ImagePickerBackground">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="ImagePickerImagePreviewBackground">
+        <Background Type="CT_RAW" Source="FFF5F5F5" />
+      </Color>
+      <Color Name="AppDesignerTabActiveBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="AppDesignerForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="AppDesignerActiveSelectionBackground">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="AppDesignerActiveSelectionForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AppDesignerActiveSelectionBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="AppDesignerInactiveSelectionBackground">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="AppDesignerInactiveSelectionForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="AppDesignerInactiveSelectionBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="SharedFieldsDataGridHeaderText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="EntityDesignerFieldListClientTitleBackground">
+        <Background Type="CT_RAW" Source="FFCA5100" />
+      </Color>
+      <Color Name="DialogDropDownBackground">
+        <Background Type="CT_RAW" Source="FFFCFCFC" />
+      </Color>
+      <Color Name="DialogDropDownBorder">
+        <Background Type="CT_RAW" Source="FFEAEBF0" />
+      </Color>
+      <Color Name="DialogDropDownButtonMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownButtonMouseDownSeparator">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownButtonMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDropDownButtonMouseOverSeparator">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownDisabledBackground">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDropDownDisabledBorder">
+        <Background Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="DialogDropDownDisabledGlyph">
+        <Background Type="CT_RAW" Source="FFC6C6C6" />
+      </Color>
+      <Color Name="DialogDropDownDisabledText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="DialogDropDownGlyph">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDropDownMouseDownBackground">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownMouseDownBorder">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownMouseDownGlyph">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DialogDropDownMouseDownText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDropDownMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DialogDropDownMouseOverBorder">
+        <Background Type="CT_RAW" Source="FFEAEBF0" />
+      </Color>
+      <Color Name="DialogDropDownMouseOverGlyph">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogDropDownMouseOverText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDropDownPopupBackground">
+        <Background Type="CT_RAW" Source="FFE7E8EC" />
+      </Color>
+      <Color Name="DialogDropDownPopupBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="DialogDropDownText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDropDownTextSelection">
+        <Background Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="DialogTextSelection">
+        <Background Type="CT_RAW" Source="FF0E70C0" />
+      </Color>
+      <Color Name="DialogDataGridBackground">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDataGridBorder">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDataGridElementBackground1">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDataGridElementBackground2">
+        <Background Type="CT_RAW" Source="FFF6F6F6" />
+      </Color>
+      <Color Name="DialogDataGridElementDisabledBackground">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDataGridRowBorder">
+        <Background Type="CT_RAW" Source="00FFFFFF" />
+      </Color>
+      <Color Name="DialogDataGridRowDisabledText">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="DialogDataGridRowHeaderDark">
+        <Background Type="CT_RAW" Source="FFEFEFF2" />
+      </Color>
+      <Color Name="DialogDataGridRowHeaderLight">
+        <Background Type="CT_RAW" Source="FFF6F6F6" />
+      </Color>
+      <Color Name="DialogDataGridRowMouseOverBackground">
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+      </Color>
+      <Color Name="DialogDataGridRowMouseOverText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDataGridRowSelectedBackground">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="DialogDataGridRowSelectedText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="DialogDataGridRowText">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogDataGridRowTitle">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="DialogDataGridSelectRowBorder">
+        <Background Type="CT_RAW" Source="FFCCCEDB" />
+      </Color>
+      <Color Name="AddRelationshipEntityDesignerRelatedEntityBackground">
+        <Background Type="CT_RAW" Source="FFF6F6F6" />
+      </Color>
+      <Color Name="AddRelationshipEntityDesignerRelatedEntityForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="AddRelationshipEntityDesignerRelatedEntitySelectedHeaderBackground">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="AddRelationshipEntityDesignerRelatedEntitySelectedHeaderForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AddRelationshipEntityDesignerRelatedEntitySelectedLine">
+        <Background Type="CT_RAW" Source="FF007ACC" />
+      </Color>
+      <Color Name="DialogTreeViewDisabledForeground">
+        <Background Type="CT_RAW" Source="FFA2A4A5" />
+      </Color>
+      <Color Name="DialogTreeViewForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogTreeViewSelectedBackground">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="DialogTreeViewSelectedBorder">
+        <Background Type="CT_RAW" Source="FF3399FF" />
+      </Color>
+      <Color Name="DialogTreeViewSelectedForeground">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TreeArrowMouseOverStroke">
+        <Background Type="CT_RAW" Source="FF1BBBFA" />
+      </Color>
+      <Color Name="TreeArrowIsCheckedFill">
+        <Background Type="CT_RAW" Source="FF595959" />
+      </Color>
+      <Color Name="TreeArrowIsCheckedStroke">
+        <Background Type="CT_RAW" Source="FF262626" />
+      </Color>
+      <Color Name="TreeArrowStroke">
+        <Background Type="CT_RAW" Source="FF989898" />
+      </Color>
+      <Color Name="DialogTextBoxForeground">
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
+      </Color>
+      <Color Name="DialogLabelRunModeForeground">
+        <Background Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="DialogListItemText">
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+    </Category>
+    <Category Name="SolutionErrorFilter" GUID="{669949b4-7f07-4ee5-919a-5d7635b30b7d}">
+      <Color Name="ErrorSquiggle">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+      </Color>
+      <Color Name="WarningSquiggle">
+        <Background Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="InfoSquiggle">
+        <Background Type="CT_RAW" Source="FF9BD1E1" />
+      </Color>
+      <Color Name="ErrorListPopup">
+        <Background Type="CT_RAW" Source="FF003C49" />
+        <Foreground Type="CT_RAW" Source="FF839496" />
+      </Color>
+      <Color Name="ErrorListPopupBorder">
+        <Background Type="CT_RAW" Source="FF92CAF4" />
+      </Color>
+      <Color Name="ErrorSquiggleSelectedActive">
+        <Background Type="CT_RAW" Source="FFFF9999" />
+      </Color>
+      <Color Name="WarningSquiggleSelectedActive">
+        <Background Type="CT_RAW" Source="FFCCFFCC" />
+      </Color>
+      <Color Name="InfoSquiggleSelectedActive">
+        <Background Type="CT_RAW" Source="FFCCCCFF" />
+      </Color>
+      <Color Name="ErrorSquiggleSelectedInactive">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+      </Color>
+      <Color Name="WarningSquiggleSelectedInactive">
+        <Background Type="CT_RAW" Source="FF95DB7D" />
+      </Color>
+      <Color Name="InfoSquiggleSelectedInactive">
+        <Background Type="CT_RAW" Source="FF9BD1E1" />
+      </Color>
+      <Color Name="ErrorListSelectedItem">
+        <Background Type="CT_RAW" Source="FF096D82" />
+        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ErrorListHeader">
+        <Background Type="CT_RAW" Source="FF002B36" />
+        <Foreground Type="CT_RAW" Source="FF839496" />
+      </Color>
+    </Category>
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+        <Color Name="AccentFillDefault">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="AccentFillSecondary">
+            <Background Type="CT_RAW" Source="39082CE5" />
+        </Color>
+        <Color Name="AccentFillTertiary">
+            <Background Type="CT_RAW" Source="39082CCC" />
+        </Color>
+        <Color Name="SolidBackgroundFillTertiary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SolidBackgroundFillQuaternary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SurfaceBackgroundFillDefault">
+            <Background Type="CT_RAW" Source="FF2C2C2C" />
+        </Color>
+        <Color Name="TextFillSecondary">
+            <Background Type="CT_RAW" Source="FFFFFFCC" />
+        </Color>
+    </Category>
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+        <Color Name="EnvironmentBackground">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="EnvironmentBorder">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentBorderInactive">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentIndicator">
+            <Background Type="CT_RAW" Source="ffffff60" />
+        </Color>
+        <Color Name="EnvironmentLogo">
+            <Background Type="CT_RAW" Source="FFEE0077" />
+        </Color>
+        <Color Name="EnvironmentLayeredBackground">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+        <Color Name="StatusBarBackgroundFillSolutionLoading">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+    </Category>
+    </Theme>
+</Themes>

--- a/Cyberpunk Theme/CyberpunkTheme.vstheme
+++ b/Cyberpunk Theme/CyberpunkTheme.vstheme
@@ -1,5 +1,5 @@
 ﻿<Themes>
-  <Theme Name="Cyberpunk" GUID="{37868443-43b2-4023-a370-220a0e3449dd}" BaseGUID="{a147e2d4-5eda-4c9d-9e1f-7fcde5307581}">
+  <Theme Name="Cyberpunk" GUID="{37868443-43b2-4023-a370-220a0e3449dd}" BaseGUID="{a147e2d4-5eda-4c9d-9e1f-7fcde5307581}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
     <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
       <Color Name="Body">
         <Background Type="CT_RAW" Source="FF090C1D" />
@@ -12761,5 +12761,51 @@
         <Foreground Type="CT_RAW" Source="FF839496" />
       </Color>
     </Category>
-  </Theme>
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+        <Color Name="AccentFillDefault">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="AccentFillSecondary">
+            <Background Type="CT_RAW" Source="39082CE5" />
+        </Color>
+        <Color Name="AccentFillTertiary">
+            <Background Type="CT_RAW" Source="39082CCC" />
+        </Color>
+        <Color Name="SolidBackgroundFillTertiary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SolidBackgroundFillQuaternary">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="SurfaceBackgroundFillDefault">
+            <Background Type="CT_RAW" Source="FF2C2C2C" />
+        </Color>
+        <Color Name="TextFillSecondary">
+            <Background Type="CT_RAW" Source="FFFFFFCC" />
+        </Color>
+    </Category>
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+        <Color Name="EnvironmentBackground">
+            <Background Type="CT_RAW" Source="FF000B1E" />
+        </Color>
+        <Color Name="EnvironmentBorder">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentBorderInactive">
+            <Background Type="CT_RAW" Source="FF39082C" />
+        </Color>
+        <Color Name="EnvironmentIndicator">
+            <Background Type="CT_RAW" Source="ffffff60" />
+        </Color>
+        <Color Name="EnvironmentLogo">
+            <Background Type="CT_RAW" Source="FFEE0077" />
+        </Color>
+        <Color Name="EnvironmentLayeredBackground">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+        <Color Name="StatusBarBackgroundFillSolutionLoading">
+            <Background Type="CT_RAW" Source="0000004D" />
+        </Color>
+    </Category>
+    </Theme>
 </Themes>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyberpunk-Theme
 
-Dark "Cyberpunk" theme for visual studio 2019 and 2022 <br>
+Dark "Cyberpunk" theme for visual studio 2019, 2022, and 2026. <br>
 # C#
 <img src="https://github.com/T0uchM3/Cyberpunk-Theme/blob/master/Cyberpunk%20Theme/preview2.png"><br>
 # C++ (OLD)


### PR DESCRIPTION
Updates the vstheme file to include the new sections necessary for VS 2026, and adds a second vstheme for "Cyberpunk (classic)" which has the "traditional" coloring for c# - for anyone who prefers that traditional look.

This is in no way meant to denigrate the work of headless-horsman recent controbutions; I just personally prefer the older coloring, so would love to keep a way of accessing it for anyone else who might feel the same. 

![2025-12-11_15-57-26](https://github.com/user-attachments/assets/289630f5-8b21-42f0-8246-d97995c3ae06)
![2025-12-11_15-57-48](https://github.com/user-attachments/assets/62b3402e-86f2-4242-a40c-31a81b9f651a)
